### PR TITLE
Added search fields "is_admin" and "is_member" for spaces

### DIFF
--- a/src/graphql/operations/spaces.ts
+++ b/src/graphql/operations/spaces.ts
@@ -6,6 +6,15 @@ export default async function(parent, args) {
   let queryStr = '';
   const params: any[] = [];
 
+  if (where['is_admin']) {
+    queryStr += `AND JSON_CONTAINS(settings->"$.admins", ?)`;
+    params.push(`"${where['is_admin']}"`);
+  }
+  if (where['is_member']) {
+    queryStr += `AND JSON_CONTAINS(settings->"$.members", ?)`;
+    params.push(`"${where['is_member']}"`);
+  }
+
   const fields = ['id'];
   fields.forEach(field => {
     if (where[field]) {

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -60,7 +60,9 @@ type Query {
 
 input SpaceWhere {
   id: String
-  id_in: [String]
+  id_in: [String],
+  is_admin: String,
+  is_member: String
 }
 
 input ProposalWhere {


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot/issues/871

Uses https://dev.mysql.com/doc/refman/5.7/en/json-search-functions.html#function_json-contains to search in the `settings` JSON field.

Test queries:
```graphql
query AdminSpaces {
  spaces(
    where: { is_admin: "0x123..." }
  ) {
    id
    admins
    members
  }
}

query MemberSpaces {
  spaces(
    where: { is_member: "0x456..." }
  ) {
    id
    admins
    members
  }
}
```