### PR TITLE
fix spaces count for strategy and plugin

### DIFF
--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -57,9 +57,10 @@ router.get('/explore', (req, res) => {
       ? networks[space.network] + 1
       : 1;
 
-    space.strategies.forEach(strategy => {
-      strategies[strategy.name] = strategies[strategy.name]
-        ? strategies[strategy.name] + 1
+    const uniqueStrategies = new Set<string>(space.strategies.map((strategy) =>strategy.name));
+    uniqueStrategies.forEach(strategyName => {
+      strategies[strategyName] = strategies[strategyName]
+        ? strategies[strategyName] + 1
         : 1;
     });
 


### PR DESCRIPTION
Fixes # https://github.com/snapshot-labs/snapshot/issues/922
## Summary
Changes proposed in this pull request:
Strategies might be used multiple times in a space, so as plugins. 
Try to deduplicate strategies and plugins by name before processing it for each space.
## Test



response from  https://snapshot-hub-master-udn6q21tgz.herokuapp.com/api/explore
shows that we have 12 spaces using ticket strategy

![image](https://user-images.githubusercontent.com/3824034/143677560-766300ab-2544-4f60-8423-fe2eefd5dfc8.png)

After checking https://snapshot-hub-master-udn6q21tgz.herokuapp.com/api/spaces 
find there are 12 spaces using that strategy with 1 space use it twice. So the result is now correct.
