### PR TITLE
chore: updated docker compose and added gh workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,49 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish Docker image
+
+on:
+  # For every new published release, build the docker image and publish it to GH
+  release:
+    types: [published]
+
+  # For every push to master, build the docker image and publish it to GH
+  push:
+    branches: 
+      - master
+
+jobs:
+  publish_docker_image:
+    name: Push Docker image to Github Container Registry
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      
+      - name: Log in to the Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata (tags, labels) for Docker Image
+        id: meta
+        uses: docker/metadata-action@v2
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,19 @@ RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y git python make g++
 
 # Create the application workdir
-RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
+RUN mkdir -p /home/node/app/uploads && chown -R node:node /home/node/app/uploads
 WORKDIR /home/node/app
 
 # Set current user
 USER node
 
 # Copy app dependencies
-# A wildcard is used to ensure both package.json AND package-lock.json are copied
 COPY package*.json ./
+COPY renovate*.json ./
 
 # Install app dependencies
-RUN npm install
+RUN npm ci
 
 # Bundle app source
 COPY --chown=node:node . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,23 +6,28 @@ services:
     build: .
     container_name: snapshot-hub
     env_file:
-      - .env.local
+      - .env
+    environment:
+      DATABASE_URL: mysql://admin:pwd@snapshot-mysql:3306/snapshot
+    
     depends_on:
       - snapshot-mysql
     ports:
-      - "8080:8080"
+      - "3000:3000"
 
   # Snapshot MySQL instance
   snapshot-mysql:
-    image: mysql:8.0.21
+    image: mysql:5.7
     container_name: snapshot-mysql
+    ports:
+      - 3306:3306
     environment:
       MYSQL_USER: "admin"
-      MYSQL_PASSWORD: "admin"
+      MYSQL_PASSWORD: "pwd"
       MYSQL_ROOT_PASSWORD: "admin"
       MYSQL_DATABASE: "snapshot"
     volumes:
-        - ./server/helpers/database/:/docker-entrypoint-initdb.d
+        - "./src/helpers/database/:/docker-entrypoint-initdb.d/"
 
 networks:
   default:


### PR DESCRIPTION
Changes proposed in this pull request:
- Updated docker-compose to work with latest version of snapshot-hub 
- Added gh workflow to publish the docker image to the Github Container Registry
