### PR TITLE
followerCount for space(s)

### DIFF
--- a/src/graphql/operations/space.ts
+++ b/src/graphql/operations/space.ts
@@ -3,7 +3,7 @@ import { formatSpace } from '../helpers';
 
 export default async function(_parent, { id }) {
   const query = `
-    SELECT s.*, COUNT(f.id) as followerCount FROM spaces s
+    SELECT s.*, COUNT(f.id) as followersCount FROM spaces s
     JOIN follows f ON f.space = s.id
     WHERE s.id = ? AND s.settings IS NOT NULL
     GROUP BY s.id

--- a/src/graphql/operations/space.ts
+++ b/src/graphql/operations/space.ts
@@ -1,16 +1,18 @@
 import db from '../../helpers/mysql';
 import { formatSpace } from '../helpers';
 
-export default async function(parent, { id }) {
+export default async function(_parent, { id }) {
   const query = `
-    SELECT * FROM spaces
-    WHERE id = ? AND spaces.settings IS NOT NULL
+    SELECT s.*, COUNT(f.id) as followerCount FROM spaces s
+    JOIN follows f ON f.space = s.id
+    WHERE s.id = ? AND s.settings IS NOT NULL
+    GROUP BY s.id
     LIMIT 1
   `;
   try {
     const spaces = await db.queryAsync(query, [id]);
     return (
-      spaces.map(space => formatSpace(space.id, space.settings))[0] || null
+      spaces.map(space => Object.assign(space, formatSpace(space.id, space.settings)))[0] || null
     );
   } catch (e) {
     console.log('[graphql]', e);

--- a/src/graphql/operations/spaces.ts
+++ b/src/graphql/operations/spaces.ts
@@ -1,7 +1,7 @@
 import db from '../../helpers/mysql';
 import { formatSpace } from '../helpers';
 
-export default async function(parent, args) {
+export default async function(_parent, args) {
   const { where = {} } = args;
   let queryStr = '';
   const params: any[] = [];
@@ -9,12 +9,12 @@ export default async function(parent, args) {
   const fields = ['id'];
   fields.forEach(field => {
     if (where[field]) {
-      queryStr += `AND ${field} = ? `;
+      queryStr += `AND s.${field} = ? `;
       params.push(where[field]);
     }
     const fieldIn = where[`${field}_in`] || [];
     if (fieldIn.length > 0) {
-      queryStr += `AND ${field} IN (?) `;
+      queryStr += `AND s.${field} IN (?) `;
       params.push(fieldIn);
     }
   });
@@ -32,13 +32,15 @@ export default async function(parent, args) {
   params.push(skip, first);
 
   const query = `
-    SELECT * FROM spaces
+    SELECT s.*, COUNT(f.id) as followerCount FROM spaces s
+    JOIN follows f ON f.space = s.id
     WHERE 1 = 1 ${queryStr}
-    ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?
+    GROUP BY s.id
+    ORDER BY s.${orderBy} ${orderDirection} LIMIT ?, ?
   `;
   try {
     const spaces = await db.queryAsync(query, params);
-    return spaces.map(space => formatSpace(space.id, space.settings));
+    return spaces.map(space => Object.assign(space, formatSpace(space.id, space.settings)));
   } catch (e) {
     console.log('[graphql]', e);
     return Promise.reject('request failed');

--- a/src/graphql/operations/spaces.ts
+++ b/src/graphql/operations/spaces.ts
@@ -32,7 +32,7 @@ export default async function(_parent, args) {
   params.push(skip, first);
 
   const query = `
-    SELECT s.*, COUNT(f.id) as followerCount FROM spaces s
+    SELECT s.*, COUNT(f.id) as followersCount FROM spaces s
     JOIN follows f ON f.space = s.id
     WHERE 1 = 1 ${queryStr}
     GROUP BY s.id

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -208,7 +208,7 @@ type Space {
   voting: SpaceVoting
   categories: [String]
   validation: Strategy
-  followerCount: Int
+  followersCount: Int
 }
 
 type SpaceFilters {

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -208,6 +208,7 @@ type Space {
   voting: SpaceVoting
   categories: [String]
   validation: Strategy
+  followerCount: Int
 }
 
 type SpaceFilters {


### PR DESCRIPTION
Added a `JOIN` to the space queries, to count followers and added a `followerCount` to the Space type.
This affects all GraphQL queries now but I can also make it depend on `followerCount` being present or not. But we need to work on the hub quite a bit anyway so I left it that simple.

Note:
- `Object.assign` to not loose data from the query after using `formatSpace`
- `parent` => `_parent`: Just a naming convention for unused parameters (doesn't belong here, shame on me)
