### PR TITLE
fixed query to not return null if no followers

### DIFF
--- a/src/graphql/operations/space.ts
+++ b/src/graphql/operations/space.ts
@@ -4,7 +4,7 @@ import { formatSpace } from '../helpers';
 export default async function(_parent, { id }) {
   const query = `
     SELECT s.*, COUNT(f.id) as followersCount FROM spaces s
-    JOIN follows f ON f.space = s.id
+    LEFT JOIN follows f ON f.space = s.id
     WHERE s.id = ? AND s.settings IS NOT NULL
     GROUP BY s.id
     LIMIT 1

--- a/src/graphql/operations/spaces.ts
+++ b/src/graphql/operations/spaces.ts
@@ -33,7 +33,7 @@ export default async function(_parent, args) {
 
   const query = `
     SELECT s.*, COUNT(f.id) as followersCount FROM spaces s
-    JOIN follows f ON f.space = s.id
+    LEFT JOIN follows f ON f.space = s.id
     WHERE 1 = 1 ${queryStr}
     GROUP BY s.id
     ORDER BY s.${orderBy} ${orderDirection} LIMIT ?, ?


### PR DESCRIPTION
Fixes spaces without followers not loading.

reason:
`JOIN` = null, if there's nothing on the right side table
`LEFT JOIN` = keep "left" table data, even if right side is empty
