### PR TITLE
load space metadata right after loading spaces

### DIFF
--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -57,6 +57,8 @@ async function loadSpaces() {
     );
     const totalSpaces = Object.keys(spaces).length;
     console.log('[spaces] Total spaces', totalSpaces);
+    
+    loadSpacesMetrics();
   });
 }
 


### PR DESCRIPTION
Currently you have to wait 32 seconds for the explore endpoint to return something, every time you restart the hub, which is a bit annoying during development. So that function is now simply called right after loading the spaces.