### PR TITLE
feat(): add network property to strategy

### DIFF
--- a/src/graphql/examples.ts
+++ b/src/graphql/examples.ts
@@ -13,6 +13,7 @@ query Spaces {
     symbol
     strategies {
       name
+      network
       params
     }
     admins

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -26,6 +26,11 @@ export function formatSpace(id, settings) {
   space.proposalsCount = spaceProposals[id]?.count || 0;
   space.voting.hideAbstain = space.voting.hideAbstain || false;
   space.validation = space.validation || { name: 'basic', params: {} };
+  space.strategies = space.strategies.map(strategy => ({
+    ...strategy,
+    // By default return space network if strategy network is not defined
+    network: strategy.network || space.network
+  }));
   return space;
 }
 

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -266,6 +266,7 @@ type Proposal {
 
 type Strategy {
   name: String!
+  network: String
   params: Any
 }
 


### PR DESCRIPTION
Added network property which will be later used to display the network in the space settings for each strategy.  
