### PR TITLE
changed proposal quorrum to float/decimal

### DIFF
--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -255,7 +255,7 @@ type Proposal {
   choices: [String]!
   start: Int!
   end: Int!
-  quorum: Int!
+  quorum: Float!
   snapshot: String
   state: String
   link: String

--- a/src/helpers/database/schema.sql
+++ b/src/helpers/database/schema.sql
@@ -59,7 +59,7 @@ CREATE TABLE proposals (
   choices JSON NOT NULL,
   start INT(11) NOT NULL,
   end INT(11) NOT NULL,
-  quorum INT(32) NOT NULL,
+  quorum DECIMAL(64,30) NOT NULL,
   snapshot INT(24) NOT NULL,
   scores JSON NOT NULL,
   scores_by_strategy JSON NOT NULL,


### PR DESCRIPTION
Quorum is of type float in `SpaceVoting` but on proposal [it was now added](https://github.com/snapshot-labs/snapshot-hub/pull/282/files) as int.

In my local env I had 0.5 (ETH) set as a quorum, which was now suddenly rounded to 1 in the proposal table, leading to surprises when prioritizing it over the space setting.

(Not sure about the reasoning behind `64/30` for the scores field but I used the same values for quorum now. Should be more than sufficient.)