### PR TITLE
Increase rate limit

### DIFF
--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -3,7 +3,7 @@ import { sendError, sha256 } from './utils';
 
 export default rateLimit({
   windowMs: 16 * 1e3,
-  max: 64,
+  max: 128,
   handler: (req, res) => {
     const id = sha256(req.ip);
     console.log('Too many requests', id.slice(0, 7));


### PR DESCRIPTION
"Fixes" https://github.com/snapshot-labs/snapshot/issues/2122

I don't know how the current rate limitation came to be but it seems to be a bit too tight. It's 4 requests per second, which can be achieved manually, e.g. by quickly joining spaces (as in the above issue) or if we'd try to do multiple requests programmatically, as I'd first tried in the Sub-DAO feature to circumvent adjusting the GraphQL API, which I now did instead.

The same issue can also cause the delegation page to break.

![image](https://user-images.githubusercontent.com/6792578/162479314-fe8ad02c-237f-462e-913b-28947e9d2fc8.png)

I just went with doubling the requests now in this PR from 4 to 8 (128 per 16s) but I see that these values have been [adjusted in the past](https://github.com/snapshot-labs/snapshot-hub/commits/master/src/helpers/rateLimit.ts). So I'm not sure if it should be increased like this.

The other aspect of this issue is of course that these things need to be handled properly in the UI. Currently it tends to simply break if there's a problem on the backend side.