### PR TITLE
enforce min value 1 for choices in basic and single-choice

### DIFF
--- a/src/writer/vote.ts
+++ b/src/writer/vote.ts
@@ -33,7 +33,7 @@ export async function verify(body): Promise<any> {
     (!proposal.type ||
       proposal.type === 'single-choice' ||
       proposal.type === 'basic') &&
-    typeof msg.payload.choice !== 'number'
+    (typeof msg.payload.choice !== 'number' || msg.payload.choice < 1)
   )
     return Promise.reject('invalid choice');
 

--- a/src/writer/vote.ts
+++ b/src/writer/vote.ts
@@ -39,12 +39,17 @@ export async function verify(body): Promise<any> {
 
   if (
     ['approval', 'ranked-choice'].includes(proposal.type) &&
-    !Array.isArray(msg.payload.choice)
+    (!Array.isArray(msg.payload.choice) || Math.min(...msg.payload.choice) < 1)
   )
     return Promise.reject('invalid choice');
 
   if (['weighted', 'quadratic'].includes(proposal.type)) {
-    if (typeof msg.payload.choice !== 'object')
+    if (
+      typeof msg.payload.choice !== 'object' ||
+      Math.min(
+        ...Object.keys(msg.payload.choice).map(choice => Number(choice))
+      ) < 1
+    )
       return Promise.reject('invalid choice');
 
     let choiceIsValid = true;


### PR DESCRIPTION
Choices starting at 1 was not enforced in the hub, leaving the possibility of a custom integration sending 0 and also calculating and displaying results accordingly.
