### PR TITLE
Fix strategies null or object

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -46,6 +46,9 @@ export function formatUser(user) {
 export function formatProposal(proposal) {
   proposal.choices = jsonParse(proposal.choices, []);
   proposal.strategies = jsonParse(proposal.strategies, []);
+  proposal.strategies = Array.isArray(proposal.strategies)
+    ? proposal.strategies
+    : [];
   proposal.plugins = jsonParse(proposal.plugins, {});
   proposal.scores = jsonParse(proposal.scores, []);
   proposal.scores_by_strategy = jsonParse(proposal.scores_by_strategy, []);


### PR DESCRIPTION
Problem:
Try this following query on hub:
```JS
query {
    proposals (
    first: 62
    skip: 0
    orderBy: "created"
    orderDirection: asc
    where: {
      created_gt: 1637909052
      state: "closed"
    }
  ) {
    id
  }
 }
 ```
 
 We get this error:
 
 ```js
 ﻿[graphql] TypeError: proposal.strategies.map is not a function﻿
```

Reason: previously we used to accept whatever the metadata sent from the proposal payload, so I assume there could be an object in `strategies` instead of an array, this PR will handle that case and will return an empty array if `strategies` is not an array