### PR TITLE
Move authors and onlyMembers validation to the hub

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -47,7 +47,7 @@ export function rpcError(res, code, e, id) {
 }
 
 export function hasStrategyOverride(strategies: any[]) {
-  const keywords =  [
+  const keywords = [
     '"api"',
     '"api-post"',
     '"aura-vlaura-vebal-with-overrides"',


### PR DESCRIPTION
Currently we do this check on Snapshot.js, with this PR I'm moving the logic to allow authors to publish a proposal as a core feature.