### PR TITLE
Space settings: add aliased param to space voting setting

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -27,6 +27,7 @@ export function formatSpace(id, settings) {
   space.voting.quorum = space.voting.quorum || null;
   space.voting.blind = space.voting.blind || false;
   space.voting.privacy = space.voting.privacy || '';
+  space.voting.aliased = space.voting.aliased || false;
   space.followersCount = spaceFollowers[id]?.count || 0;
   space.proposalsCount = spaceProposals[id]?.count || 0;
   space.voting.hideAbstain = space.voting.hideAbstain || false;

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -312,6 +312,7 @@ type SpaceVoting {
   blind: Boolean
   hideAbstain: Boolean
   privacy: String
+  aliased: Boolean
 }
 
 type Proposal {


### PR DESCRIPTION
Fixes [2844](https://github.com/snapshot-labs/snapshot/issues/2844).

**To merge with:**
- [snapshot.js](https://github.com/snapshot-labs/snapshot.js/pull/746)
- [snapshot](https://github.com/snapshot-labs/snapshot/pull/3265)

Changes proposed in this pull request:
- add `aliased` parameter to the `space.voting` settings
