### PR TITLE
Don't allow reason in vote request if shutter enabled

### DIFF
--- a/src/ingestor/typedData/index.ts
+++ b/src/ingestor/typedData/index.ts
@@ -88,17 +88,15 @@ export default async function ingestor(body) {
   if (type === 'delete-proposal') payload = { proposal: message.proposal };
 
   if (['vote', 'vote-array', 'vote-string'].includes(type)) {
-    const proposal = await getProposal(message.space, message.proposal);
     let choice = message.choice;
-    let reason = message.reason;
-    if (proposal.privacy === 'shutter') reason = '';
     if (type === 'vote-string') {
+      const proposal = await getProposal(message.space, message.proposal);
       if (proposal.privacy !== 'shutter') choice = JSON.parse(message.choice);
     }
     payload = {
       proposal: message.proposal,
       choice,
-      reason,
+      reason: message.reason || '',
       app: kebabCase(message.app || '')
     };
     type = 'vote';

--- a/src/ingestor/typedData/index.ts
+++ b/src/ingestor/typedData/index.ts
@@ -88,15 +88,17 @@ export default async function ingestor(body) {
   if (type === 'delete-proposal') payload = { proposal: message.proposal };
 
   if (['vote', 'vote-array', 'vote-string'].includes(type)) {
+    const proposal = await getProposal(message.space, message.proposal);
     let choice = message.choice;
+    let reason = message.reason;
+    if (proposal.privacy === 'shutter') reason = '';
     if (type === 'vote-string') {
-      const proposal = await getProposal(message.space, message.proposal);
       if (proposal.privacy !== 'shutter') choice = JSON.parse(message.choice);
     }
     payload = {
       proposal: message.proposal,
       choice,
-      reason: message.reason || '',
+      reason,
       app: kebabCase(message.app || '')
     };
     type = 'vote';

--- a/src/ingestor/writer/vote.ts
+++ b/src/ingestor/writer/vote.ts
@@ -39,6 +39,8 @@ export async function verify(body): Promise<any> {
   if (proposal.privacy === 'shutter') {
     if (typeof msg.payload.choice !== 'string' || !msg.payload.choice.startsWith('0x'))
       return Promise.reject('invalid choice');
+    if (msg.payload.reason.length !== 0)
+      return Promise.reject('no reason allowed on proposal with Shutter privacy enabled');
   } else {
     if (!snapshot.utils.voting[proposal.type].isValidChoice(msg.payload.choice, proposal.choices))
       return Promise.reject('invalid choice');
@@ -58,8 +60,7 @@ export async function verify(body): Promise<any> {
     if (vp.vp === 0) return Promise.reject('no voting power');
   } catch (e) {
     log.warn(
-      `[writer] Failed to check voting power (vote), ${msg.space}, ${body.address}, ${
-        proposal.snapshot
+      `[writer] Failed to check voting power (vote), ${msg.space}, ${body.address}, ${proposal.snapshot
       }, ${JSON.stringify(e)}`
     );
     return Promise.reject('failed to check voting power');

--- a/src/ingestor/writer/vote.ts
+++ b/src/ingestor/writer/vote.ts
@@ -39,8 +39,8 @@ export async function verify(body): Promise<any> {
   if (proposal.privacy === 'shutter') {
     if (typeof msg.payload.choice !== 'string' || !msg.payload.choice.startsWith('0x'))
       return Promise.reject('invalid choice');
-    if (msg.payload.reason.length !== 0)
-      return Promise.reject('no reason allowed on proposal with Shutter privacy enabled');
+    if (msg.payload.reason?.length)
+      return Promise.reject('reason not allowed with shutter');
   } else {
     if (!snapshot.utils.voting[proposal.type].isValidChoice(msg.payload.choice, proposal.choices))
       return Promise.reject('invalid choice');

--- a/src/ingestor/writer/vote.ts
+++ b/src/ingestor/writer/vote.ts
@@ -60,7 +60,8 @@ export async function verify(body): Promise<any> {
     if (vp.vp === 0) return Promise.reject('no voting power');
   } catch (e) {
     log.warn(
-      `[writer] Failed to check voting power (vote), ${msg.space}, ${body.address}, ${proposal.snapshot
+      `[writer] Failed to check voting power (vote), ${msg.space}, ${body.address}, ${
+        proposal.snapshot
       }, ${JSON.stringify(e)}`
     );
     return Promise.reject('failed to check voting power');


### PR DESCRIPTION
Fixes #491 .

Changes proposed in this pull request:
- Reject requests that have a reason when shutter is enabled