### PR TITLE
Integrate with keycard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@ PORT=3000
 NETWORK=testnet
 DATABASE_URL=mysql://...
 SEQUENCER_URL=https://testnet.seq.snapshot.org
-KEYCARD_URL=
+KEYCARD_URL=https://keycard.snapshot.org
 KEYCARD_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,5 @@ NETWORK=testnet
 DATABASE_URL=mysql://...
 DEFAULT_NETWORK=1
 SEQUENCER_URL=https://testnet.seq.snapshot.org
+KEYCARD_URL=
 KEYCARD_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ NETWORK=testnet
 DATABASE_URL=mysql://...
 DEFAULT_NETWORK=1
 SEQUENCER_URL=https://testnet.seq.snapshot.org
+KEYCARD_SECRET=

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@ethersproject/hash": "^5.5.0",
     "@ethersproject/providers": "^5.6.8",
     "@ethersproject/wallet": "^5.6.2",
+    "@snapshot-labs/keycard": "^0.1.0",
     "@snapshot-labs/pineapple": "^0.1.0-beta.1",
     "@snapshot-labs/snapshot.js": "^0.4.83",
     "bluebird": "^3.7.2",

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -15,6 +15,6 @@ const schema = makeExecutableSchema({ typeDefs, resolvers: rootValue });
 export default graphqlHTTP({
   schema,
   rootValue,
-  graphiql: { defaultQuery },
+  graphiql: { defaultQuery, headerEditorEnabled: true },
   validationRules: [queryCountLimit(5, 5), depthLimit(5)]
 });

--- a/src/helpers/keycard.ts
+++ b/src/helpers/keycard.ts
@@ -1,0 +1,9 @@
+import { Keycard } from '@snapshot-labs/keycard';
+
+const keycard = new Keycard({
+  app: 'snapshot-hub',
+  secret: process.env.KEYCARD_SECRET,
+  URL: 'http://localhost:8888'
+});
+
+export default keycard;

--- a/src/helpers/keycard.ts
+++ b/src/helpers/keycard.ts
@@ -7,7 +7,7 @@ const keycard = new Keycard({
   URL: process.env.KEYCARD_URL || 'http://localhost:3002'
 });
 
-const checkKeyCard = async (req, res, next) => {
+const verifyKeyCard = async (req, res, next) => {
   const key = req.headers['x-api-key'] || req.query.apiKey;
   if (key && keycard.configured) {
     const { valid, rateLimited } = keycard.logReq(key);
@@ -18,4 +18,4 @@ const checkKeyCard = async (req, res, next) => {
   return next();
 };
 
-export { keycard, checkKeyCard };
+export { keycard, verifyKeyCard };

--- a/src/helpers/keycard.ts
+++ b/src/helpers/keycard.ts
@@ -4,7 +4,7 @@ import { sendError } from './utils';
 const keycard = new Keycard({
   app: 'snapshot-hub',
   secret: process.env.KEYCARD_SECRET || '',
-  URL: process.env.KEYCARD_URL || 'http://localhost:3002'
+  URL: process.env.KEYCARD_URL || 'http://localhost:3007'
 });
 
 const verifyKeyCard = async (req, res, next) => {

--- a/src/helpers/keycard.ts
+++ b/src/helpers/keycard.ts
@@ -1,9 +1,21 @@
 import { Keycard } from '@snapshot-labs/keycard';
+import { sendError } from './utils';
 
 const keycard = new Keycard({
   app: 'snapshot-hub',
-  secret: process.env.KEYCARD_SECRET,
-  URL: 'http://localhost:8888'
+  secret: process.env.KEYCARD_SECRET || '',
+  URL: process.env.KEYCARD_URL || 'http://localhost:3002'
 });
 
-export default keycard;
+const checkKeyCard = async (req, res, next) => {
+  const key = req.headers['x-api-key'] || req.query.apiKey;
+  if (key && keycard.configured) {
+    const { valid, rateLimited } = keycard.logReq(key);
+
+    if (!valid) return sendError(res, 'invalid api key', 401);
+    if (rateLimited) return sendError(res, 'too many requests', 429);
+  }
+  return next();
+};
+
+export { keycard, checkKeyCard };

--- a/src/helpers/keycard.ts
+++ b/src/helpers/keycard.ts
@@ -4,7 +4,7 @@ import { sendError } from './utils';
 const keycard = new Keycard({
   app: 'snapshot-hub',
   secret: process.env.KEYCARD_SECRET || '',
-  URL: process.env.KEYCARD_URL || 'http://localhost:3007'
+  URL: process.env.KEYCARD_URL || 'https://keycard.snapshot.org'
 });
 
 const verifyKeyCard = async (req, res, next) => {

--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -10,8 +10,7 @@ export default rateLimit({
   standardHeaders: true,
   skip: req => {
     const key = req.headers['x-api-key'] || req.query.apiKey;
-    if (key && keycard.configured) return true;
-    return false;
+    return key && keycard.configured;
   },
   handler: (req, res) => {
     // const id = sha256(getIp(req));

--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -9,7 +9,7 @@ export default rateLimit({
   keyGenerator: req => getIp(req),
   standardHeaders: true,
   skip: (req, res) => {
-    if (keycard.configured && req.headers['x-snapshot-keycard']) return true;
+    if (keycard.configured && req.headers['x-api-key']) return true;
 
     res.locals.ignoreKeycardCheck = true;
     return false;

--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -1,17 +1,16 @@
 import rateLimit from 'express-rate-limit';
 import { getIp, sendError } from './utils';
 import log from './log';
-import keycard from './keycard';
+import { keycard } from './keycard';
 
 export default rateLimit({
   windowMs: 20 * 1e3,
   max: 60,
   keyGenerator: req => getIp(req),
   standardHeaders: true,
-  skip: (req, res) => {
-    if (keycard.configured && req.headers['x-api-key']) return true;
-
-    res.locals.ignoreKeycardCheck = true;
+  skip: req => {
+    const key = req.headers['x-api-key'] || req.query.apiKey;
+    if (key && keycard.configured) return true;
     return false;
   },
   handler: (req, res) => {

--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -1,15 +1,26 @@
 import rateLimit from 'express-rate-limit';
 import { getIp, sendError } from './utils';
 import log from './log';
+import keycard from './keycard';
 
 export default rateLimit({
   windowMs: 20 * 1e3,
   max: 60,
   keyGenerator: req => getIp(req),
   standardHeaders: true,
+  skip: (req, res) => {
+    if (keycard.configured && req.headers['x-snapshot-keycard']) return true;
+
+    res.locals.ignoreKeycardCheck = true;
+    return false;
+  },
   handler: (req, res) => {
     // const id = sha256(getIp(req));
     log.info(`too many requests ${getIp(req).slice(0, 7)}`);
-    sendError(res, 'too many requests', 429);
+    sendError(
+      res,
+      'too many requests, Refer: https://twitter.com/SnapshotLabs/status/1605567222713196544',
+      429
+    );
   }
 });

--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -13,7 +13,6 @@ export default rateLimit({
     return key && keycard.configured;
   },
   handler: (req, res) => {
-    // const id = sha256(getIp(req));
     log.info(`too many requests ${getIp(req).slice(0, 7)}`);
     sendError(
       res,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import graphql from './graphql';
 import rateLimit from './helpers/rateLimit';
 import log from './helpers/log';
 import './helpers/strategies';
-import { checkKeyCard } from './helpers/keycard';
+import { verifyKeyCard } from './helpers/keycard';
 
 const app = express();
 app.use(express.json({ limit: '20mb' }));
@@ -15,7 +15,7 @@ app.use(cors({ maxAge: 86400 }));
 app.set('trust proxy', 1);
 app.use(rateLimit);
 app.use('/api', api);
-app.use('/graphql', checkKeyCard, graphql);
+app.use('/graphql', verifyKeyCard, graphql);
 app.get('/*', (req, res) => res.redirect('/api'));
 
 const PORT = process.env.PORT || 3000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import graphql from './graphql';
 import rateLimit from './helpers/rateLimit';
 import log from './helpers/log';
 import './helpers/strategies';
+import keycard from './helpers/keycard';
 
 const app = express();
 app.use(express.json({ limit: '20mb' }));
@@ -14,7 +15,7 @@ app.use(cors({ maxAge: 86400 }));
 app.set('trust proxy', 1);
 app.use(rateLimit);
 app.use('/api', api);
-app.use('/graphql', graphql);
+app.use('/graphql', keycard.checkHeader, graphql);
 app.get('/*', (req, res) => res.redirect('/api'));
 
 const PORT = process.env.PORT || 3000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import graphql from './graphql';
 import rateLimit from './helpers/rateLimit';
 import log from './helpers/log';
 import './helpers/strategies';
-import keycard from './helpers/keycard';
+import { checkKeyCard } from './helpers/keycard';
 
 const app = express();
 app.use(express.json({ limit: '20mb' }));
@@ -15,7 +15,7 @@ app.use(cors({ maxAge: 86400 }));
 app.set('trust proxy', 1);
 app.use(rateLimit);
 app.use('/api', api);
-app.use('/graphql', keycard.checkHeader, graphql);
+app.use('/graphql', checkKeyCard, graphql);
 app.get('/*', (req, res) => res.redirect('/api'));
 
 const PORT = process.env.PORT || 3000;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,6 +1224,13 @@
   dependencies:
     "@snapshot-labs/eslint-config-base" "^0.1.0-beta.7"
 
+"@snapshot-labs/keycard@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/keycard/-/keycard-0.1.0.tgz#4904a43a61b48f7b0d0db02246f8a104d1daa536"
+  integrity sha512-CSbioDWmR5nqxYpEAJBzEbLXn8ucsg3arCLI2tgdhDIskH8n19Pzo21jELjql+/zUM8sPMQKnhmv1xTAIq9I4w==
+  dependencies:
+    cross-fetch "^3.1.5"
+
 "@snapshot-labs/pineapple@^0.1.0-beta.1":
   version "0.1.0-beta.1"
   resolved "https://registry.yarnpkg.com/@snapshot-labs/pineapple/-/pineapple-0.1.0-beta.1.tgz#4b136b778bff741c85df474ebfa202e8b1c9969a"


### PR DESCRIPTION
If you want to pass headers into the GraphQL editor, with this PR we can see a Request headers tab beside Query variables like in the below screenshot (make sure to hard reload if you don't see it)
![image](https://github.com/snapshot-labs/snapshot-hub/assets/15967809/af267906-8ae1-42ef-afc5-6a1f4654c1a2)

Admin tasks:
- [ ] Update `KEYCARD_SECRET` 