### PR TITLE
Remove DEFAULT_NETWORK env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 PORT=3000
 NETWORK=testnet
 DATABASE_URL=mysql://...
-DEFAULT_NETWORK=1
 SEQUENCER_URL=https://testnet.seq.snapshot.org


### PR DESCRIPTION
We moved this env to snapshot-sequencer, so not used anywhere on the hub