### PR TITLE
Default to  `any` validation

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -61,7 +61,7 @@ export function formatSpace(id, settings) {
   space.proposalsCount = spaceProposals[id]?.count || 0;
   space.voting.hideAbstain = space.voting.hideAbstain || false;
   space.voteValidation = space.voteValidation || { name: 'any', params: {} };
-  space.validation = space.validation || { name: 'basic', params: {} };
+  space.validation = space.validation || { name: 'any', params: {} };
   space.strategies = space.strategies?.map(strategy => ({
     ...strategy,
     // By default return space network if strategy network is not defined


### PR DESCRIPTION
We now default to `any` validation instead of `basic`

Merge only after https://github.com/snapshot-labs/snapshot-sequencer/pull/30