### PR TITLE
Fix default validation if minScore exist in filters

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -61,12 +61,18 @@ export function formatSpace(id, settings) {
   space.proposalsCount = spaceProposals[id]?.count || 0;
   space.voting.hideAbstain = space.voting.hideAbstain || false;
   space.voteValidation = space.voteValidation || { name: 'any', params: {} };
-  space.validation = space.validation || { name: 'any', params: {} };
   space.strategies = space.strategies?.map(strategy => ({
     ...strategy,
     // By default return space network if strategy network is not defined
     network: strategy.network || space.network
   }));
+  space.validation = space.validation || { name: 'any', params: {} };
+  if (space.validation.name === 'any' && space.filters.minScore) {
+    space.validation = {
+      name: 'basic',
+      params: { minScore: space.filters.minScore, strategies: space.strategies }
+    };
+  }
   space.treasuries = space.treasuries || [];
 
   // always return parent and children in child node format

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -66,13 +66,13 @@ export function formatSpace(id, settings) {
     // By default return space network if strategy network is not defined
     network: strategy.network || space.network
   }));
-  space.validation = space.validation || { name: 'any', params: {} };
-  if (space.validation.name === 'any' && space.filters.minScore) {
+  if (!space.validation && space.filters.minScore) {
     space.validation = {
       name: 'basic',
       params: { minScore: space.filters.minScore, strategies: space.strategies }
     };
   }
+  space.validation = space.validation || { name: 'any', params: {} };
   space.treasuries = space.treasuries || [];
 
   // always return parent and children in child node format


### PR DESCRIPTION
There are still a few spaces that use `space.filters.minScore` but have empty  validations, which means it is a basic validation and uses space strategies

example space:
https://hub.snapshot.org/api/spaces/gnosis.eth 

Reported by:
https://discord.com/channels/707079246388133940/1090583087156572231/1090583087156572231