### PR TITLE
feat: Order by rank

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "snapshot-spaces"]
+	path = snapshot-spaces
+	url = https://github.com/snapshot-labs/snapshot-spaces

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { spaces, spacesMetadata } from './helpers/spaces';
+import { spaces, exploreEndpointData } from './helpers/spaces';
 import { name, version } from '../package.json';
 import { sendError } from './helpers/utils';
 
@@ -26,7 +26,7 @@ router.get('/', (req, res) => {
 });
 
 router.get('/explore', (req, res) => {
-  return res.json({ spaces: spacesMetadata });
+  return res.json({ spaces: exploreEndpointData });
 });
 
 router.get('/spaces/:key', (req, res) => {

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -97,6 +97,7 @@ type Query {
 input SpaceWhere {
   id: String
   id_in: [String]
+  id_contains: String
 }
 
 input MessageWhere {
@@ -317,6 +318,8 @@ type Space {
   children: [Space]
   guidelines: String
   template: String
+  verified: Int
+  rank: Float
 }
 
 type SpaceFilters {

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -2,16 +2,34 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import { uniq } from 'lodash';
 import db from './mysql';
 import log from './log';
+import verifiedSpaces from '../../snapshot-spaces/spaces/verified.json';
 
 export let spaces = {};
+export const exploreEndpointData = {};
 export const spacesMetadata = {};
 export const spaceProposals = {};
 export const spaceVotes = {};
 export const spaceFollowers = {};
 
+function getRank(id: string, verified: number): number {
+  let ranking =
+    (spaceVotes[id]?.count || 0) / 50 +
+    (spaceVotes[id]?.count_7d || 0) +
+    (spaceProposals[id]?.count_7d || 0) * 50 +
+    (spaceFollowers[id]?.count_7d || 0);
+
+  if (verified) {
+    ranking = ranking * 5;
+    ranking += 100;
+  }
+
+  return ranking;
+}
+
 function mapSpaces() {
   Object.entries(spaces).forEach(([id, space]: any) => {
-    spacesMetadata[id] = {
+    /* This will be deprecated soon */
+    exploreEndpointData[id] = {
       name: space.name,
       private: space.private || undefined,
       terms: space.terms || undefined,
@@ -26,6 +44,14 @@ function mapSpaces() {
       votes_7d: (spaceVotes[id] && spaceVotes[id].count_7d) || undefined,
       followers: (spaceFollowers[id] && spaceFollowers[id].count) || undefined,
       followers_7d: (spaceFollowers[id] && spaceFollowers[id].count_7d) || undefined
+    };
+    /* This will be deprecated soon */
+
+    spacesMetadata[id] = {
+      id,
+      verified: verifiedSpaces[id] || 0,
+      rank: getRank(id, verifiedSpaces[id]),
+      private: space.private || undefined
     };
   });
 }


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/snapshot/issues/1437

- [x] Order by rank
- [x] Ignores private space if sorted by rank
- [x] Search with the id string
- [ ] Search with  `category` and `network` 
- [ ] New Query to get metrics like total spaces, total networks, total strategies, and total plugins
