### PR TITLE
refactor(mysql): split db name and db path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 PORT=3000
 NETWORK=testnet
 DATABASE_URL=mysql://...
+MYSQL_DATABASE_NAME=snapshot-relayer
 SEQUENCER_URL=https://testnet.seq.snapshot.org

--- a/src/helpers/mysql.ts
+++ b/src/helpers/mysql.ts
@@ -8,8 +8,9 @@ import log from './log';
 const connectionLimit = parseInt(process.env.CONNECTION_LIMIT || '25');
 log.info(`[mysql] connection limit ${connectionLimit}`);
 
+const mysqlUrl = `${process.env.DATABASE_URL}/${process.env.MYSQL_DATABASE_NAME}`;
 // @ts-ignore
-const config = parse(process.env.DATABASE_URL);
+const config = parse(mysqlUrl);
 config.connectionLimit = connectionLimit;
 config.multipleStatements = true;
 config.database = config.path[0];


### PR DESCRIPTION
Changes proposed in this pull request:
- split DB name and DB path. It's needed for flexible configuration of docker containers
