### PR TITLE
chore: fix lint task

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,4 +12,4 @@ jobs:
           cache: 'yarn'
       - run: yarn
       - run: yarn lint:nofix
-      - run: yarn typescript
+      - run: yarn typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,8 @@
-name: Test
+name: Lint
 on: [push]
 
 jobs:
-  build-test:
+  lint:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -11,4 +11,5 @@ jobs:
           node-version: '16'
           cache: 'yarn'
       - run: yarn
-      - run: yarn lint
+      - run: yarn lint:nofix
+      - run: yarn typescript

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "repository": "snapshot-labs/snapshot-hub",
   "license": "MIT",
   "scripts": {
-    "lint": "eslint . --ext .ts --fix",
+    "lint": "yarn lint:nofix --fix",
+    "lint:nofix": "eslint . --ext .ts",
+    "typecheck": "tsc --noEmit",
     "dev": "nodemon src/index.ts",
     "start": "ts-node src/index.ts"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "strict": true,
     "noImplicitAny": false,
+    "skipLibCheck": true,
     "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The current "Test" task on CI is not running test, but lint
The lint task is running with --fix, so all errors will be ignored

## 💊 Fixes / Solution

Rename the task, and raise errors on lint task

## 🚧 Changes

- Rename task from Test to Lint
- the `lint` task should raise warnings on errors, so removing the `--fix` argument
- Add a new `typecheck` task, to lint Typescript 

## 🛠️ Tests

- Run `yarn lint`
- Run `yarn typecheck`