### PR TITLE
Query to filter flagged proposals

### DIFF
--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -66,7 +66,7 @@ export default async function (parent, args) {
   }
 
   if (where.flagged === true) {
-    searchSql += ' AND p.id in (?)';
+    searchSql += ' AND p.id IN (?)';
     params.push(flaggedProposals);
   }
 

--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -1,7 +1,7 @@
 import db from '../../helpers/mysql';
 import { buildWhereQuery, formatProposal, checkLimits } from '../helpers';
 import log from '../../helpers/log';
-import { verifiedSpaces } from '../../helpers/moderation';
+import { flaggedProposals, verifiedSpaces } from '../../helpers/moderation';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export default async function (parent, args) {
@@ -63,6 +63,16 @@ export default async function (parent, args) {
   if (where.space_verified) {
     searchSql += ' AND spaces.id in (?)';
     params.push(verifiedSpaces);
+  }
+
+  if (where.flagged === true) {
+    searchSql += ' AND p.id in (?)';
+    params.push(flaggedProposals);
+  }
+
+  if (where.flagged === false) {
+    searchSql += ' AND p.id not in (?)';
+    params.push(flaggedProposals);
   }
 
   let orderBy = args.orderBy || 'created';

--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -71,7 +71,7 @@ export default async function (parent, args) {
   }
 
   if (where.flagged === false) {
-    searchSql += ' AND p.id not in (?)';
+    searchSql += ' AND p.id NOT IN (?)';
     params.push(flaggedProposals);
   }
 

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -200,6 +200,7 @@ input ProposalWhere {
   scores_state_in: [String]
   state: String
   space_verified: Boolean
+  flagged: Boolean
 }
 
 input VoteWhere {


### PR DESCRIPTION
How to test:
- To return all proposals:
  ```
  {
    proposals(first:1000){
      id
      space {
        id
      }
      flagged
    }
  }
  ```

- To return only flagged proposals:
  ```
  {
    proposals(first:1000, where:{flagged:true}){
      id
      space {
        id
      }
      flagged
    }
  }
  ```
- To return only nonflagged proposals:
  ```
  {
    proposals(first:1000, where:{flagged:false}){
      id
      space {
        id
      }
      flagged
    }
  }
  ```
