### PR TITLE
chore: fix wrong branch name in workflow

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -2,7 +2,7 @@ name: Create a Sentry release
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
 jobs:
   create-sentry-release:
     uses: snapshot-labs/actions/.github/workflows/create-sentry-release.yml@main


### PR DESCRIPTION
The workflow is using `main` instead of `master`, thus not being triggered