### PR TITLE
chore: allow a certain number of fails before reporting the error to Sentry

### DIFF
--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -3,6 +3,7 @@ import log from './log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 const moderationURL = 'https://sh5.co/api/moderation';
+let consecutiveFailsCount = 0;
 
 export let flaggedLinks: Array<string> = [];
 export let flaggedProposals: Array<string> = [];
@@ -20,8 +21,13 @@ async function loadModerationData() {
 async function run() {
   try {
     await loadModerationData();
+    consecutiveFailsCount = 0;
   } catch (e: any) {
-    capture(e, { context: { url: moderationURL } });
+    consecutiveFailsCount++;
+
+    if (consecutiveFailsCount >= 5) {
+      capture(e, { context: { url: moderationURL } });
+    }
     log.error(`[moderation] failed to load ${JSON.stringify(e)}`);
   }
   await snapshot.utils.sleep(5e3);

--- a/src/helpers/strategies.ts
+++ b/src/helpers/strategies.ts
@@ -7,6 +7,7 @@ export let strategies: any[] = [];
 export let strategiesObj: any = {};
 
 const uri = 'https://score.snapshot.org/api/strategies';
+let consecutiveFailsCount = 0;
 
 async function loadStrategies() {
   const res = await snapshot.utils.getJSON(uri);
@@ -34,8 +35,13 @@ async function loadStrategies() {
 async function run() {
   try {
     await loadStrategies();
+    consecutiveFailsCount = 0;
   } catch (e: any) {
-    capture(e);
+    consecutiveFailsCount++;
+
+    if (consecutiveFailsCount >= 3) {
+      capture(e);
+    }
     log.error(`[strategies] failed to load ${JSON.stringify(e)}`);
   }
   await snapshot.utils.sleep(60e3);


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Retrieving data frequently from our own some services (sidekick and score) can temporary fail for various reasons (deploy progress, etc ...)

From the sentry logs, we can see that these fail at least once a day. 

As the data is already cached, and the query is for updating it periodically, the query is allowed to fail a few times without real impact, and should raise an error only when it fails consecutively.

## 💊 Fixes / Solution

All temporary network errors should be muted, unless they're raised consecutively more than N times (which means something really wrong, and not temporary). 

This will remove a lot of noises from our error reporting.

Fixes SNAPSHOT-HUB-5
Fixes SNAPSHOT-HUB-6
Fixes SNAPSHOT-HUB-8

## 🚧 Changes

- Add a counter to store the number of times the query fail
- When a query fails consecutively more than n time, report the error to senrtry

## 🛠️ Tests

