### PR TITLE
Return limits and remaining count in headers

### DIFF
--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -1,16 +1,19 @@
 import rateLimit from 'express-rate-limit';
 import { getIp, sendError } from './utils';
 import log from './log';
-import { keycard } from './keycard';
 
 export default rateLimit({
   windowMs: 20 * 1e3,
   max: 60,
   keyGenerator: req => getIp(req),
   standardHeaders: true,
-  skip: req => {
-    const key = req.headers['x-api-key'] || req.query.apiKey;
-    return key && keycard.configured;
+  skip: (req, res) => {
+    const keycardData = res.locals.keycardData;
+    if (keycardData?.valid && !keycardData.rateLimited) {
+      return true;
+    }
+
+    return false;
   },
   handler: (req, res) => {
     log.info(`too many requests ${getIp(req).slice(0, 7)}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import graphql from './graphql';
 import rateLimit from './helpers/rateLimit';
 import log from './helpers/log';
 import './helpers/strategies';
-import { verifyKeyCard } from './helpers/keycard';
+import { checkKeycard } from './helpers/keycard';
 import './helpers/moderation';
 import { initLogger, fallbackLogger } from '@snapshot-labs/snapshot-sentry';
 
@@ -19,9 +19,9 @@ app.use(express.json({ limit: '20mb' }));
 app.use(express.urlencoded({ limit: '20mb', extended: false }));
 app.use(cors({ maxAge: 86400 }));
 app.set('trust proxy', 1);
-app.use(rateLimit);
+app.use(checkKeycard, rateLimit);
 app.use('/api', api);
-app.use('/graphql', verifyKeyCard, graphql);
+app.use('/graphql', graphql);
 
 fallbackLogger(app);
 app.get('/*', (req, res) => res.redirect('/api'));


### PR DESCRIPTION
🔴 Need a new version from https://github.com/snapshot-labs/keycard.js/pull/7

Summary of changes:

- Use new values returned from keycard.js
- Return remaining count, limits and reset time in headers
  <img width="263" alt="Untitled 3" src="https://github.com/snapshot-labs/snapshot-hub/assets/15967809/7f2c223d-a931-4e96-9d99-221f06e723a5">
- Fallback to default rate limit if the max number of requests on keycard is reached


How to test:
1. Install the new version of keycard.js with `yarn link` or wait for the new version to be released
2. Run the server
3. Go to `http://localhost:3000/graphql?apiKey=1234` (replace apiKey if required)
4. Try sending the requests and look into the networks tab in console
5. It should display the correct limits and remaining count
6. If it reaches our limit, it should fall back to the default rate limit (express-rate-limit)
