### PR TITLE
fix: fix error when passing invalid first and skip value to SQL

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -37,6 +37,10 @@ export function checkLimits(args: any = {}, type) {
     const whereLimitReached = key.endsWith('_in') ? where[key]?.length > limit : where[key] > limit;
     if (firstLimitReached || skipLimitReached || whereLimitReached)
       throw new Error(`The \`${key}\` argument must not be greater than ${limit}`);
+
+    if (['first', 'skip'].includes(key) && args[key] < 0) {
+      throw new Error(`The \`${key}\` argument must be positive`);
+    }
   }
   return true;
 }


### PR DESCRIPTION
Fix #648 
Fix SNAPSHOT-HUB-C

Fix error when people are passing invalid (negative) values to `skip` and `first` argument, such as 

```
query Votes {
  votes(first: -20, skip: -20, where: {proposal: "", created_gte: 0}, orderBy: "created", orderDirection: asc) {
    id
    voter
    created
    choice
    reason
    space {
      id
    }
  }
}

```