### PR TITLE
chore: relax dependabot rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,4 @@ updates:
     schedule:
       interval: "daily"
     allow:
-      # Allow updates for snapshot.js only
-      - dependency-name: "@snapshot-labs/snapshot.js"
+      - dependency-name: "@snapshot-labs/*"


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Dependabot only updates package for snapshot.js. It should also monitor all other packages from  @snapshot-labs orgs

## 💊 Fixes / Solution

Make dependabot create PR on new packages from the same org

## 🚧 Changes

- relax dependabot rule to include all packages from @snapshot-labs

## 🛠️ Tests

- N/A