### PR TITLE
chore: normalize graphql path in metrics

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -33,7 +33,8 @@ export default function initMetrics(app: Express) {
   init(app, {
     normalizedPath: [
       ['^/api/scores/.+', '/api/scores/#id'],
-      ['^/api/spaces/([^/]+)(/poke)?$', '/api/spaces/#key$2']
+      ['^/api/spaces/([^/]+)(/poke)?$', '/api/spaces/#key$2'],
+      ['^/graphql/?$', '/graphql']
     ],
     whitelistedPath,
     errorHandler: (e: any) => capture(e)


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The metrics endpoint is logging a lot of noise from the `/graphql` path, due to people trying to find vulnerabilities, and getting metrics for path like `/graphql/../../[random-system-file]`

## 💊 Fixes / Solution

Ignore all those request by grouping all requests under just `/graph` endpoint

## 🚧 Changes

- Normalize all path starting by `/graphql`

## 🛠️ Tests

- N/A