### PR TITLE
feat(flag proposal): add ability to flag proposal

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -258,7 +258,12 @@ export function formatUser(user) {
 
 function isFlaggedProposal(proposal) {
   const flaggedLinksRegex = new RegExp(flaggedLinks.join('|'), 'i');
-  return flaggedProposals?.includes(proposal.id) || flaggedLinksRegex.test(proposal.body);
+  return (
+    // TODO: remove this check once flagged proposals are migrated to hub db via script
+    flaggedProposals?.includes(proposal.id) ||
+    flaggedLinksRegex.test(proposal.body) ||
+    proposal.flagged
+  );
 }
 
 export function formatProposal(proposal) {

--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -66,13 +66,15 @@ export default async function (parent, args) {
     params.push(verifiedSpaces);
   }
 
+  // TODO: remove part `p.id IN (?)` when flagged proposals are moved from laser DB to snapshot-sequencer DB
   if (where.flagged === true && flaggedProposals.length > 0) {
-    searchSql += ' AND p.id IN (?)';
+    searchSql += ' AND (p.id IN (?) OR p.flagged = 1)';
     params.push(flaggedProposals);
   }
 
+  // TODO: remove part `p.id NOT IN (?)` when flagged proposals are moved from laser DB to snapshot-sequencer DB
   if (where.flagged === false && flaggedProposals.length > 0) {
-    searchSql += ' AND p.id NOT IN (?)';
+    searchSql += ' AND (p.id NOT IN (?) AND p.flagged = 0)';
     params.push(flaggedProposals);
   }
 

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -58,7 +58,7 @@ CREATE TABLE proposals (
   INDEX app (app),
   INDEX scores_state (scores_state),
   INDEX scores_updated (scores_updated),
-  INDEX votes (votes)
+  INDEX votes (votes),
   INDEX flagged (flagged)
 );
 

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -44,6 +44,7 @@ CREATE TABLE proposals (
   scores_total DECIMAL(64,30) NOT NULL,
   scores_updated INT(11) NOT NULL,
   votes INT(12) NOT NULL,
+  flagged INT NOT NULL DEFAULT 0,
   PRIMARY KEY (id),
   INDEX ipfs (ipfs),
   INDEX author (author),
@@ -58,6 +59,7 @@ CREATE TABLE proposals (
   INDEX scores_state (scores_state),
   INDEX scores_updated (scores_updated),
   INDEX votes (votes)
+  INDEX flagged (flagged)
 );
 
 CREATE TABLE votes (


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix query builder to get flagged/not flagged proposals
- modified graphql helper
- fix SQL schema

TODO:
- [x] Create a new column with 
```sql
ALTER TABLE proposals 
ADD COLUMN flagged INT NOT NULL DEFAULT 0,
ADD INDEX flagged (flagged);
```

Notes:
This PR doesn't remove the previous implementation and is backward compatible. The previous implementation will be removed when data is migrated from the laser DB to the new column. Probably it will be done in a separate PR