### PR TITLE
feature: Add new roles query

### DIFF
--- a/src/graphql/operations/index.ts
+++ b/src/graphql/operations/index.ts
@@ -20,6 +20,7 @@ import statement from './statement';
 import vp from './vp';
 import messages from './messages';
 import ranking from './ranking';
+import roles from './roles';
 
 export default {
   space,
@@ -43,5 +44,6 @@ export default {
   statements,
   statement,
   vp,
-  messages
+  messages,
+  roles
 };

--- a/src/graphql/operations/roles.ts
+++ b/src/graphql/operations/roles.ts
@@ -2,11 +2,6 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import db from '../../helpers/mysql';
 import log from '../../helpers/log';
 
-interface Role {
-  space: string;
-  permissions: string[];
-}
-
 export default async function (parent, args) {
   const { where = {} } = args;
 
@@ -34,7 +29,7 @@ export default async function (parent, args) {
 
       if (admins.includes(address.toLowerCase())) permissions.push('admin');
       if (moderators.includes(address.toLowerCase())) permissions.push('moderator');
-      if (members.includes(address.toLowerCase())) permissions.push('member');
+      if (members.includes(address.toLowerCase())) permissions.push('author');
 
       return { space: space.id, permissions };
     });

--- a/src/graphql/operations/roles.ts
+++ b/src/graphql/operations/roles.ts
@@ -1,0 +1,46 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import db from '../../helpers/mysql';
+import log from '../../helpers/log';
+
+interface Role {
+  space: string;
+  permissions: string[];
+}
+
+export default async function (parent, args) {
+  const { where = {} } = args;
+
+  const { address } = where;
+  if (!address) return Promise.reject(new Error('address is required'));
+
+  const query = `
+    SELECT * FROM spaces
+    WHERE JSON_CONTAINS(LOWER(settings->'$.admins'), LOWER(?))
+      OR JSON_CONTAINS(LOWER(settings->'$.members'), LOWER(?))
+      OR JSON_CONTAINS(LOWER(settings->'$.moderators'), LOWER(?));
+  `;
+  const params: string[] = [`"${address}"`, `"${address}"`, `"${address}"`];
+
+  try {
+    const data = await db.queryAsync(query, params);
+    return data.map((space: any) => {
+      const settings = JSON.parse(space.settings);
+      const permissions: string[] = [];
+      const admins = (settings.admins || []).map((admin: string) => admin.toLowerCase());
+      const moderators = (settings.moderators || []).map((moderator: string) =>
+        moderator.toLowerCase()
+      );
+      const members = (settings.members || []).map((member: string) => member.toLowerCase());
+
+      if (admins.includes(address.toLowerCase())) permissions.push('admin');
+      if (moderators.includes(address.toLowerCase())) permissions.push('moderator');
+      if (members.includes(address.toLowerCase())) permissions.push('member');
+
+      return { space: space.id, permissions };
+    });
+  } catch (e: any) {
+    log.error(`[graphql] roles, ${JSON.stringify(e)}`);
+    capture(e, { args });
+    return Promise.reject(new Error('request failed'));
+  }
+}

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -47,6 +47,10 @@ type Query {
     orderDirection: OrderDirection
   ): [Alias]
 
+  roles(
+    where: RolesWhere
+  ): [Role]
+
   follows(
     first: Int
     skip: Int
@@ -259,6 +263,10 @@ input AliasWhere {
   created_gte: Int
   created_lt: Int
   created_lte: Int
+}
+
+input RolesWhere {
+  address: String
 }
 
 input FollowWhere {
@@ -476,6 +484,11 @@ type Alias {
   address: String!
   alias: String!
   created: Int!
+}
+
+type Role {
+  space: String
+  permissions: [String]
 }
 
 type Follow {


### PR DESCRIPTION
### Why?

To get roles of an address across all spaces 

### How to test?
- Run this following query with an address that is `admin` or `moderator` or `member` of space
```
{
  roles(where:{address:"0xef8305e140ac520225daf050e2f71d5fbcc543e7"}) {
    space
    permissions
  }
}
```