### PR TITLE
feat: Use sequencer DB for messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 PORT=3000
 NETWORK=testnet
-DATABASE_URL=mysql://...
+HUB_DATABASE_URL=mysql://...
+SEQ_DATABASE_URL=mysql://
 SEQUENCER_URL=https://testnet.seq.snapshot.org
 KEYCARD_URL=https://keycard.snapshot.org
 KEYCARD_SECRET=

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ yarn
 
 2. Copy [`.env.example`](https://github.com/snapshot-labs/snapshot-hub/blob/master/.env.example), rename it to `.env` and set a value for these config vars:
 
-- `DATABASE_URL`: The database connection string. You will need to run your own MySQL database or use a Cloud service like [JawsDB](https://jawsdb.com).
+- `HUB_DATABASE_URL`: The database connection string. You will need to run your own MySQL database or use a Cloud service like [JawsDB](https://jawsdb.com).
 - `RELAYER_PK`: This is the private key of the hub. The hub counter-sign every accepted message with this key.
 
 3. Create the database schema

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ yarn
 2. Copy [`.env.example`](https://github.com/snapshot-labs/snapshot-hub/blob/master/.env.example), rename it to `.env` and set a value for these config vars:
 
 - `HUB_DATABASE_URL`: The database connection string. You will need to run your own MySQL database or use a Cloud service like [JawsDB](https://jawsdb.com).
+- `SEQ_DATABASE_URL`:  We now use `messages` from a different database, it can be same as `HUB_DATABASE_URL` in your local
 - `RELAYER_PK`: This is the private key of the hub. The hub counter-sign every accepted message with this key.
 
 3. Create the database schema

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - .env
     environment:
       HUB_DATABASE_URL: mysql://admin:pwd@snapshot-mysql:3306/snapshot
+      SEQ_DATABASE_URL: mysql://admin:pwd@snapshot-mysql:3306/snapshot
 
     depends_on:
       - snapshot-mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     env_file:
       - .env
     environment:
-      DATABASE_URL: mysql://admin:pwd@snapshot-mysql:3306/snapshot
-    
+      HUB_DATABASE_URL: mysql://admin:pwd@snapshot-mysql:3306/snapshot
+
     depends_on:
       - snapshot-mysql
     ports:

--- a/src/graphql/operations/messages.ts
+++ b/src/graphql/operations/messages.ts
@@ -1,4 +1,4 @@
-import db from '../../helpers/mysql';
+import { sequencerDB } from '../../helpers/mysql';
 import { buildWhereQuery, checkLimits } from '../helpers';
 import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
@@ -34,7 +34,7 @@ export default async function (parent, args) {
   `;
   params.push(skip, first);
   try {
-    return await db.queryAsync(query, params);
+    return await sequencerDB.queryAsync(query, params);
   } catch (e: any) {
     log.error(`[graphql] messages, ${JSON.stringify(e)}`);
     capture(e, { args });

--- a/src/helpers/mysql.ts
+++ b/src/helpers/mysql.ts
@@ -37,5 +37,4 @@ const sequencerDB = mysql.createPool(sequencerConfig);
 
 bluebird.promisifyAll([Pool, Connection]);
 
-export default hubDB;
-export { hubDB, sequencerDB };
+export { hubDB as default, sequencerDB };

--- a/src/helpers/mysql.ts
+++ b/src/helpers/mysql.ts
@@ -19,7 +19,7 @@ hubConfig.connectTimeout = 60e3;
 hubConfig.acquireTimeout = 60e3;
 hubConfig.timeout = 60e3;
 hubConfig.charset = 'utf8mb4';
-bluebird.promisifyAll([Pool, Connection]);
+
 const hubDB = mysql.createPool(hubConfig);
 
 // @ts-ignore
@@ -33,8 +33,9 @@ sequencerConfig.connectTimeout = 60e3;
 sequencerConfig.acquireTimeout = 60e3;
 sequencerConfig.timeout = 60e3;
 sequencerConfig.charset = 'utf8mb4';
-bluebird.promisifyAll([Pool, Connection]);
 const sequencerDB = mysql.createPool(sequencerConfig);
+
+bluebird.promisifyAll([Pool, Connection]);
 
 export default hubDB;
 export { hubDB, sequencerDB };

--- a/src/helpers/mysql.ts
+++ b/src/helpers/mysql.ts
@@ -9,17 +9,32 @@ const connectionLimit = parseInt(process.env.CONNECTION_LIMIT || '25');
 log.info(`[mysql] connection limit ${connectionLimit}`);
 
 // @ts-ignore
-const config = parse(process.env.DATABASE_URL);
-config.connectionLimit = connectionLimit;
-config.multipleStatements = true;
-config.database = config.path[0];
-config.host = config.hosts[0].name;
-config.port = config.hosts[0].port;
-config.connectTimeout = 60e3;
-config.acquireTimeout = 60e3;
-config.timeout = 60e3;
-config.charset = 'utf8mb4';
+const hubConfig = parse(process.env.HUB_DATABASE_URL);
+hubConfig.connectionLimit = connectionLimit;
+hubConfig.multipleStatements = true;
+hubConfig.database = hubConfig.path[0];
+hubConfig.host = hubConfig.hosts[0].name;
+hubConfig.port = hubConfig.hosts[0].port;
+hubConfig.connectTimeout = 60e3;
+hubConfig.acquireTimeout = 60e3;
+hubConfig.timeout = 60e3;
+hubConfig.charset = 'utf8mb4';
 bluebird.promisifyAll([Pool, Connection]);
-const db = mysql.createPool(config);
+const hubDB = mysql.createPool(hubConfig);
 
-export default db;
+// @ts-ignore
+const sequencerConfig = parse(process.env.SEQ_DATABASE_URL);
+sequencerConfig.connectionLimit = connectionLimit;
+sequencerConfig.multipleStatements = true;
+sequencerConfig.database = sequencerConfig.path[0];
+sequencerConfig.host = sequencerConfig.hosts[0].name;
+sequencerConfig.port = sequencerConfig.hosts[0].port;
+sequencerConfig.connectTimeout = 60e3;
+sequencerConfig.acquireTimeout = 60e3;
+sequencerConfig.timeout = 60e3;
+sequencerConfig.charset = 'utf8mb4';
+bluebird.promisifyAll([Pool, Connection]);
+const sequencerDB = mysql.createPool(sequencerConfig);
+
+export default hubDB;
+export { hubDB, sequencerDB };

--- a/test/.env.test
+++ b/test/.env.test
@@ -1,1 +1,2 @@
-DATABASE_URL=mysql://root:root@127.0.0.1:3306/hub_test
+HUB_DATABASE_URL=mysql://root:root@127.0.0.1:3306/hub_test
+SEQ_DATABASE_URL=mysql://root:root@127.0.0.1:3306/hub_test


### PR DESCRIPTION
Related to https://www.notion.so/snapshotlabs/Move-all-messages-to-sequencer-f7843f0b1f3049b79f87647ca652d181

### Changes: 
- use sequencer DB for messages table

### Important
- [x] Merge only after https://github.com/snapshot-labs/snapshot-sequencer/pull/190
- [x] Sync messages from hub DB to sequencer DB

Add following `env` to digitalocean
- [x] Create read-only user for sequencer DB
- [x] Rename `DATABASE_URL` to `HUB_DATABASE_URL`
- [x] Add new variable `SEQ_DATABASE_URL`
