### PR TITLE
fix: upgrade snapshot.js to 0.8.0 beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@snapshot-labs/keycard": "^0.4.0",
     "@snapshot-labs/snapshot-metrics": "^1.3.1",
     "@snapshot-labs/snapshot-sentry": "^1.5.1",
-    "@snapshot-labs/snapshot.js": "^0.7.2",
+    "@snapshot-labs/snapshot.js": "^0.8.0-beta.0",
     "bluebird": "^3.7.2",
     "connection-string": "^1.0.1",
     "cors": "^2.8.5",

--- a/src/graphql/operations/vp.ts
+++ b/src/graphql/operations/vp.ts
@@ -42,7 +42,7 @@ export default async function (_parent, { voter, space, proposal }) {
       });
     }
   } catch (e: any) {
-    capture(e, { input: { voter, space, proposal } });
+    capture(e, { voter, space, proposal });
     return Promise.reject(new Error('request failed'));
   }
 

--- a/src/graphql/operations/vp.ts
+++ b/src/graphql/operations/vp.ts
@@ -1,30 +1,49 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import db from '../../helpers/mysql';
 
 const scoreAPIUrl = process.env.SCORE_API_URL || 'https://score.snapshot.org';
 
 export default async function (_parent, { voter, space, proposal }) {
-  if (proposal) {
-    const query = `SELECT * FROM proposals WHERE id = ?`;
-    const [p] = await db.queryAsync(query, [proposal]);
+  if (!voter) {
+    return Promise.reject(new Error('voter is required'));
+  }
 
-    return await snapshot.utils.getVp(
-      voter,
-      p.network,
-      JSON.parse(p.strategies),
-      p.snapshot,
-      space,
-      false,
-      { url: scoreAPIUrl }
-    );
-  } else if (space) {
-    const query = `SELECT settings FROM spaces WHERE id = ? AND deleted = 0 LIMIT 1`;
-    let [s] = await db.queryAsync(query, [space]);
-    s = JSON.parse(s.settings);
+  try {
+    if (proposal) {
+      const query = `SELECT * FROM proposals WHERE id = ?`;
+      const [p] = await db.queryAsync(query, [proposal]);
 
-    return await snapshot.utils.getVp(voter, s.network, s.strategies, 'latest', space, false, {
-      url: scoreAPIUrl
-    });
+      if (!p) {
+        return Promise.reject(new Error('proposal not found'));
+      }
+
+      return await snapshot.utils.getVp(
+        voter,
+        p.network,
+        JSON.parse(p.strategies),
+        p.snapshot,
+        space,
+        false,
+        { url: scoreAPIUrl }
+      );
+    } else if (space) {
+      const query = `SELECT settings FROM spaces WHERE id = ? AND deleted = 0 LIMIT 1`;
+      let [s] = await db.queryAsync(query, [space]);
+
+      if (!s) {
+        return Promise.reject(new Error('space not found'));
+      }
+
+      s = JSON.parse(s.settings);
+
+      return await snapshot.utils.getVp(voter, s.network, s.strategies, 'latest', space, false, {
+        url: scoreAPIUrl
+      });
+    }
+  } catch (e: any) {
+    capture(e, { input: { voter, space, proposal } });
+    return Promise.reject(new Error('request failed'));
   }
 
   return Promise.reject(new Error('missing argument'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,10 +1341,10 @@
   dependencies:
     "@sentry/node" "^7.60.1"
 
-"@snapshot-labs/snapshot.js@^0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.7.2.tgz#fd0a9d5e161b9cc088771efc26f6c2bc4e887177"
-  integrity sha512-rdrS0Fj5PHYSlQrfsrNb7Vv7olRA+Lbe7f7DUNgOfzI9tQvIJJFMrQqxafyiWfnJnk4ild5iOcU5uPQPHjYVjw==
+"@snapshot-labs/snapshot.js@^0.8.0-beta.0":
+  version "0.8.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.8.0-beta.0.tgz#ec7d898ab439a6b37800dbc92e562dac9d1ef367"
+  integrity sha512-0B+qilsqQENmNf9tTXnUQ7/UVX5JLaMSyCTuJzf8+GxVGaZXGEG8TC9GdmL1q8YfJ/jXMWq9TzRjhs39ppZ6bg==
   dependencies:
     "@ensdomains/eth-ens-namehash" "^2.0.15"
     "@ethersproject/abi" "^5.6.4"
@@ -1357,9 +1357,9 @@
     "@ethersproject/wallet" "^5.6.2"
     ajv "^8.11.0"
     ajv-formats "^2.1.1"
-    cross-fetch "^3.1.6"
     json-to-graphql-query "^2.2.4"
     lodash.set "^4.3.2"
+    ofetch "^1.3.3"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -2306,13 +2306,6 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
-  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
-  dependencies:
-    node-fetch "^2.6.11"
-
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -2410,6 +2403,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+destr@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/destr/-/destr-2.0.1.tgz#2fc7bddc256fed1183e03f8d148391dde4023cb2"
+  integrity sha512-M1Ob1zPSIvlARiJUkKqvAZ3VAqQY6Jcuth/pBKQ2b1dX/Qx0OnJ8Vux6J2H5PTMQeRzWrrbTu70VxBfv/OPDJA==
 
 destroy@1.2.0:
   version "1.2.0"
@@ -4501,7 +4499,12 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-node-fetch@^2.6.11, node-fetch@^2.7.0:
+node-fetch-native@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.4.0.tgz#fbe8ac033cb6aa44bd106b5e4fd2b6277ba70fa1"
+  integrity sha512-F5kfEj95kX8tkDhUCYdV8dg3/8Olx/94zB8+ZNthFs6Bz31UpUi8Xh40TN3thLwXgrwXry1pEg9lJ++tLWTcqA==
+
+node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -4625,6 +4628,15 @@ object.values@^1.1.6:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
+
+ofetch@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/ofetch/-/ofetch-1.3.3.tgz#588cb806a28e5c66c2c47dd8994f9059a036d8c0"
+  integrity sha512-s1ZCMmQWXy4b5K/TW9i/DtiN8Ku+xCiHcjQ6/J/nDdssirrQNOoB165Zu8EqLMA2lln1JUth9a0aW9Ap2ctrUg==
+  dependencies:
+    destr "^2.0.1"
+    node-fetch-native "^1.4.0"
+    ufo "^1.3.0"
 
 on-finished@2.4.1, on-finished@^2.3.0:
   version "2.4.1"
@@ -5747,6 +5759,11 @@ typescript@^4.7.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+ufo@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.3.1.tgz#e085842f4627c41d4c1b60ebea1f75cdab4ce86b"
+  integrity sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,7 +4378,7 @@ node-fetch-native@^1.4.0:
   resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.4.0.tgz#fbe8ac033cb6aa44bd106b5e4fd2b6277ba70fa1"
   integrity sha512-F5kfEj95kX8tkDhUCYdV8dg3/8Olx/94zB8+ZNthFs6Bz31UpUi8Xh40TN3thLwXgrwXry1pEg9lJ++tLWTcqA==
 
-node-fetch@^2.6.11, node-fetch@^2.7, node-fetch@^2.7.0:
+node-fetch@^2.7, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==


### PR DESCRIPTION
Upgrade snapshot.js to 0.8.0-beta.0, with `ofetch` migration.

- Add try/catch around snapshot.utils function, and return a more meaningful error
- Return error when space or proposal are not found
- Return error when voter is blank (ideally, we should check that it's a valid address here)

There's only one file affected: operation/vp.ts

Should also fix #413 

Before upgrade, error response

```json
{
  "errors": [
    {
      "message": "Unexpected error value: { code: 500, message: \"unauthorized\", data: {} }",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "vp"
      ]
    }
  ],
  "data": {
    "vp": null
  }
}
```

After upgrade, error response:

```json
{
  "errors": [
    {
      "message": "request failed",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "vp"
      ]
    }
  ],
  "data": {
    "vp": null
  }
}
```

## Test

Working query 

```
query Vp{
  vp(space: "stgdao.eth", voter:"0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3") {
    vp_state
    vp_by_strategy
  }
}
```

Failing query

```
query Vp{
  vp(space: "magicappstore.eth", voter:"0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3") {
    vp_state
    vp_by_strategy
  }
}
```