### PR TITLE
feat: filter spaces by `strategies`, `plugins` and `network`

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -156,7 +156,7 @@ export async function fetchSpaces(args) {
 
   const fields = { id: 'string' };
   const whereQuery = buildWhereQuery(fields, 's', where);
-  const queryStr = whereQuery.query;
+  let queryStr = whereQuery.query;
   const params: any[] = whereQuery.params;
 
   let orderBy = args.orderBy || 'created_at';
@@ -164,6 +164,16 @@ export async function fetchSpaces(args) {
   if (!['created_at', 'updated_at', 'id'].includes(orderBy)) orderBy = 'created_at';
   orderDirection = orderDirection.toUpperCase();
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
+
+  if (where.strategies_in) {
+    queryStr += " AND JSON_OVERLAPS(JSON_EXTRACT(settings, '$.strategies[*].name'), JSON_ARRAY(?))";
+    params.push(where.strategies_in);
+  }
+
+  if (where.plugins_in) {
+    queryStr += " AND JSON_OVERLAPS(JSON_KEYS(settings, '$.plugins') , JSON_ARRAY(?))";
+    params.push(where.plugins_in);
+  }
 
   const query = `
     SELECT s.* FROM spaces s

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -175,6 +175,11 @@ export async function fetchSpaces(args) {
     params.push(where.plugins_in);
   }
 
+  if (where.network) {
+    queryStr += " AND JSON_EXTRACT(settings, '$.network') = ?";
+    params.push(where.network);
+  }
+
   const query = `
     SELECT s.* FROM spaces s
     WHERE s.deleted = 0 ${queryStr}

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -119,6 +119,7 @@ input SpaceWhere {
   id_in: [String]
   strategies_in: [String]
   plugins_in: [String]
+  network: String
 }
 
 input RankingWhere {

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -117,6 +117,8 @@ type Query {
 input SpaceWhere {
   id: String
   id_in: [String]
+  strategies_in: [String]
+  plugins_in: [String]
 }
 
 input RankingWhere {


### PR DESCRIPTION
Fix #548 
Fix #535 

Add `strategies_in` and `plugins_in` filter to Space.

This allow query such as:

```graphql
query Spaces {
  spaces(
    first: 10,
    where: { plugins_in: ["poap", "progress"], strategies_in: ["whitelist"], network: "1" }
  ) {
    strategies {
      name
    }
    plugins
    network
  }
}
```

Those filters behave differently than the proposal's `strategies_contains`. 

`strategies_contains` is using string search, and can match anything, such as `{`.
`strategies/plugins_in` filter will exact match the strategy/plugin name.

Feature has been applied to Proposal via https://github.com/snapshot-labs/snapshot-hub/pull/705

The strategies search only apply to level 2 strategies, and will not match nested strategies

Creating the following indices will improve search performance

```sql

ALTER TABLE spaces
ADD INDEX strategies_idx ((CAST(JSON_EXTRACT(settings, "$.strategies[*].name") AS CHAR(255) ARRAY) )) USING BTREE;

ALTER TABLE spaces
ADD INDEX plugins_idx ((CAST(JSON_KEYS(settings, "$.plugins") AS CHAR(255) ARRAY) )) USING BTREE;

ALTER TABLE spaces
ADD INDEX network_idx ((CAST(JSON_UNQUOTE(JSON_EXTRACT(settings, "$.network")) AS CHAR(255)) COLLATE utf8mb4_bin )) USING BTREE;
```

The goal of those new filters will be to enable the snapshot UI to show the list of spaces using specific network/strategy/plugin

## Note 

`JSON_OVERLAPS` require Mysql version >= 8.0.17