### PR TITLE
feat: filter proposals by `plugins` and `strategies`

### DIFF
--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -66,7 +66,7 @@ export default async function (parent, args) {
   }
 
   if (where.validation) {
-    searchSql += " AND JSON_OVERLAPS(JSON_EXTRACT(p.validation, '$.name') , JSON_ARRAY(?))";
+    searchSql += " AND JSON_EXTRACT(p.validation, '$.name') = ?";
     params.push(where.validation);
   }
 

--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -55,9 +55,19 @@ export default async function (parent, args) {
     params.push(`%${where.plugins_contains}%`);
   }
 
+  if (where.strategies_in) {
+    searchSql += " AND JSON_OVERLAPS(JSON_EXTRACT(p.strategies, '$[*].name'), JSON_ARRAY(?))";
+    params.push(where.strategies_in);
+  }
+
+  if (where.plugins_in) {
+    searchSql += ' AND JSON_OVERLAPS(JSON_KEYS(p.plugins) , JSON_ARRAY(?))';
+    params.push(where.plugins_in);
+  }
+
   if (where.validation) {
-    searchSql += ' AND p.validation LIKE ?';
-    params.push(`%"name": "${where.validation}"%`);
+    searchSql += " AND JSON_OVERLAPS(JSON_EXTRACT(p.validation, '$.name') , JSON_ARRAY(?))";
+    params.push(where.validation);
   }
 
   if (where.space_verified) {

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -177,6 +177,8 @@ input ProposalWhere {
   title_contains: String
   strategies_contains: String
   plugins_contains: String
+  strategies_in: [String]
+  plugins_in: [String]
   validation: String
   type: String
   type_in: [String]


### PR DESCRIPTION
This PR introduces a more robust proposal filtering by strategy and plugin name.

## New filter

The current existing `plugins_contains` and `strategies_contains` are just basic string search, and will return false result.

The new introduced `strategies_in` and `plugins_in` filter will searc the JSON field by key name and value, and will only return exact matches, allowing queries such as:

```graphql
query Proposals {
  proposals(first: 10, where: {plugins_in: ["aragon"]}) {
    plugins
  }
}

```

```graphql
query Proposals {
  proposals(first: 10, where: {strategies_in: ["erc721"]}) {
    strategies { name }
  }
}
```


For better performance, adding an index to the JSON objects is recommended:

```sql
ALTER TABLE proposals
ADD INDEX plugin_idx ((CAST(JSON_KEYS(plugins) AS CHAR(255) ARRAY) )) 
USING BTREE;

ALTER TABLE proposals
ADD INDEX strategies_idx ((CAST(JSON_EXTRACT(strategies, "$[*].name") AS CHAR(255) ARRAY) ))
USING BTREE;
```

## Fixing existing filter

The existing `validation` filter is using basic string search. It has been updated for a more robust search by JSON value.

```graphql
query Proposals {
  proposals(first: 10, where: {validation: "any"}) {
    validation {
      name
    }
  }
}
```

Proposed index:

```sql
ALTER TABLE proposals
ADD INDEX validation_idx ((CAST(JSON_EXTRACT(validation, "$.name") AS CHAR(255)) COLLATE utf8mb4_bin )) USING BTREE;
```