### PR TITLE
fix: Ignore api strategies from ranking calculation

### DIFF
--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -15,7 +15,7 @@ const spaceFollowers = {};
 const testnets = Object.values(networks)
   .filter((network: any) => network.testnet)
   .map((network: any) => network.key);
-const testStrategies = ['ticket'];
+const testStrategies = ['ticket', 'api', 'api-v2', 'api-post', 'api-v2-override'];
 
 function getPopularity(
   id: string,


### PR DESCRIPTION
This will reduce ranking score for spaces using these strategies