### PR TITLE
fix: instrument graphql requests

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -1,9 +1,11 @@
 import init, { client } from '@snapshot-labs/snapshot-metrics';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { Express } from 'express';
+import { Express, type Request, type Response } from 'express';
+import { parse } from 'graphql';
 import { spacesMetadata } from './spaces';
 import { strategies } from './strategies';
 import db from './mysql';
+import operations from '../graphql/operations/';
 
 const whitelistedPath = [
   /^\/$/,
@@ -30,6 +32,8 @@ function instrumentRateLimitedRequests(req, res, next) {
 }
 
 export default function initMetrics(app: Express) {
+  const GRAPHQL_TYPES = Object.keys(operations);
+
   init(app, {
     normalizedPath: [
       ['^/api/scores/.+', '/api/scores/#id'],
@@ -41,6 +45,37 @@ export default function initMetrics(app: Express) {
   });
 
   app.use(instrumentRateLimitedRequests);
+
+  app.use((req: Request, res: Response, next) => {
+    if (req.originalUrl.startsWith('/graphql')) {
+      const end = graphqlRequest.startTimer();
+
+      res.on('finish', () => {
+        try {
+          const query = parse((req.body || req.query)?.query);
+          const operationName = (req.body || req.query)?.operationName;
+
+          if (!query || !operationName) next();
+
+          // @ts-ignore
+          const definition = query.definitions.find(def => def.name.value === operationName);
+
+          // @ts-ignore
+          const types = definition.selectionSet.selections.map(sel => sel.name.value);
+
+          for (const type of types) {
+            if (GRAPHQL_TYPES.includes(type)) {
+              end({ type });
+            }
+          }
+        } catch (e: any) {
+          capture(e);
+        }
+      });
+    }
+
+    next();
+  });
 }
 
 new client.Gauge({
@@ -136,4 +171,11 @@ new client.Gauge({
 export const requestDeduplicatorSize = new client.Gauge({
   name: 'request_deduplicator_size',
   help: 'Total number of items in the deduplicator queue'
+});
+
+export const graphqlRequest = new client.Histogram({
+  name: 'graphql_requests_duration_seconds',
+  help: 'Duration in seconds of graphql requests',
+  labelNames: ['type'],
+  buckets: [0.5, 1, 2, 5, 10, 15]
 });

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -52,20 +52,22 @@ export default function initMetrics(app: Express) {
 
       res.on('finish', () => {
         try {
-          const query = parse((req.body || req.query)?.query);
+          const query = (req.body || req.query)?.query;
           const operationName = (req.body || req.query)?.operationName;
 
-          if (!query || !operationName) next();
+          if (query && operationName) {
+            const definition = parse(query).definitions.find(
+              // @ts-ignore
+              def => def.name.value === operationName
+            );
 
-          // @ts-ignore
-          const definition = query.definitions.find(def => def.name.value === operationName);
+            // @ts-ignore
+            const types = definition.selectionSet.selections.map(sel => sel.name.value);
 
-          // @ts-ignore
-          const types = definition.selectionSet.selections.map(sel => sel.name.value);
-
-          for (const type of types) {
-            if (GRAPHQL_TYPES.includes(type)) {
-              end({ type });
+            for (const type of types) {
+              if (GRAPHQL_TYPES.includes(type)) {
+                end({ type });
+              }
             }
           }
         } catch (e: any) {


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Current graphql requests are not instrumented

Will answer this kind of question: https://discord.com/channels/955773041898573854/1103266859870081114/1161683893968183367

## 💊 Fixes / Solution

Instrument the graphql requests, to extract the number of requests and response time per type (Space, Proposals, Votes, etc...)

## 🚧 Changes

- Add middleware to instrument the graphql requests

## 🛠️ Tests

- Start the service
- Send some requests to http://localhost:3000/graphql
- Go to http://localhost:3000/metrics
- You should see metrics with the key `graphql_requests_duration_seconds_bucket `