### PR TITLE
chore: add test env setup script

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,6 +16,8 @@ export default {
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-node-single-context',
   setupFiles: ['dotenv/config'],
+  globalSetup: '<rootDir>/test/setup.ts',
+  globalTeardown: '<rootDir>/test/teardown.ts',
   moduleFileExtensions: ['js', 'ts'],
   testPathIgnorePatterns: ['dist/'],
   verbose: true

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "tsc && copyfiles src/graphql/*.gql dist/",
     "start": "node dist/src/index.js",
     "start:test": "dotenv -e test/.env.test yarn dev",
+    "test:setup": "dotenv -e test/.env.test yarn ts-node ./test/setupDb.ts",
     "test": "PORT=3030 start-server-and-test 'yarn start:test' 3030 'dotenv -e test/.env.test jest --runInBand'",
     "test:unit": "dotenv -e test/.env.test jest test/unit/",
     "test:e2e": "PORT=3030 start-server-and-test 'yarn start:test' 3030 'dotenv -e test/.env.test jest --runInBand --collectCoverage=false test/e2e/'"

--- a/src/api.ts
+++ b/src/api.ts
@@ -27,6 +27,11 @@ router.get('/', (req, res) => {
 
 router.get('/spaces/:key', (req, res) => {
   const { key } = req.params;
+
+  if (!spaces[key]) {
+    return sendError(res, 'space not found', 404);
+  }
+
   return res.json(spaces[key]);
 });
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,15 @@
+import { default as db, sequencerDB } from '../src/helpers/mysql';
+
+const setup = async () => {
+  try {
+    await db.queryAsync('SELECT 1 + 1');
+    await sequencerDB.queryAsync('SELECT 1 + 1');
+  } catch (e: any) {
+    if (e.code === 'ER_BAD_DB_ERROR') {
+      console.error('Test database not setup, please run `yarn test:setup`');
+      throw new Error('Test database not setup');
+    }
+  }
+};
+
+export default setup;

--- a/test/setupDb.ts
+++ b/test/setupDb.ts
@@ -1,0 +1,62 @@
+import mysql from 'mysql';
+import Pool from 'mysql/lib/Pool';
+import Connection from 'mysql/lib/Connection';
+import bluebird from 'bluebird';
+import parse from 'connection-string';
+import fs from 'fs';
+
+// @ts-ignore
+const config = parse(process.env.HUB_DATABASE_URL);
+config.connectionLimit = 5;
+config.host = config.hosts[0].name;
+config.port = config.hosts[0].port;
+bluebird.promisifyAll([Pool, Connection]);
+const db = mysql.createPool(config);
+const dbName = config.path[0];
+
+if (!dbName.endsWith('_test')) {
+  console.error('Invalid test database name. Must end with _test');
+  process.exit(1);
+}
+
+async function run() {
+  const splitToken = ');';
+
+  console.log('Start test database setup');
+
+  console.info(`- Dropping existing database: ${dbName}`);
+  await db.queryAsync(`DROP DATABASE IF EXISTS ${dbName}`);
+
+  console.info(`- Creating new database: ${dbName}`);
+  await db.queryAsync(`CREATE DATABASE ${dbName}`);
+
+  const schema = fs
+    .readFileSync('./src/helpers/schema.sql', 'utf8')
+    .replaceAll('CREATE TABLE ', `CREATE TABLE ${dbName}.`)
+    .split(splitToken)
+    .filter(s => s.trim().length > 0);
+
+  console.info(`- Importing the schema (${schema.length} tables)`);
+
+  for (const statement of schema) {
+    await db.queryAsync(`${statement}${splitToken}`);
+  }
+
+  console.info(`Setting the permissions`);
+  await db.queryAsync(
+    `ALTER USER '${config.user}'@'localhost' IDENTIFIED WITH mysql_native_password BY '${config.password}';`
+  );
+  await db.queryAsync('FLUSH PRIVILEGES;');
+
+  console.log('Setup complete!');
+}
+
+(async () => {
+  try {
+    await run();
+    process.exit(0);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+})();

--- a/test/teardown.ts
+++ b/test/teardown.ts
@@ -1,0 +1,8 @@
+import { default as db, sequencerDB } from '../src/helpers/mysql';
+
+const teardown = async () => {
+  await db.endAsync();
+  await sequencerDB.endAsync();
+};
+
+export default teardown;


### PR DESCRIPTION
Add a yarn task `yarn test:setup` to help setup the test env

The task will recreate the test database, and import the schema