### PR TITLE
fix: Use space's verified and flagged fields from DB

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -45,7 +45,7 @@ export function checkLimits(args: any = {}, type) {
   return true;
 }
 
-export function formatSpace(id, settings) {
+export function formatSpace({ id, settings, verified, flagged }) {
   const spaceMetadata = spacesMetadata[id] || {};
   const space = { ...jsonParse(settings, {}), ...spaceMetadata.counts };
 
@@ -86,8 +86,8 @@ export function formatSpace(id, settings) {
   space.validation = space.validation || { name: 'any', params: {} };
   space.treasuries = space.treasuries || [];
 
-  space.verified = spaceMetadata?.verified ?? null;
-  space.flagged = spaceMetadata?.flagged ?? null;
+  space.verified = verified ?? null;
+  space.flagged = flagged ?? null;
   space.rank = spaceMetadata?.rank ?? null;
 
   // always return parent and children in child node format
@@ -174,7 +174,7 @@ export async function fetchSpaces(args) {
   params.push(skip, first);
 
   const spaces = await db.queryAsync(query, params);
-  return spaces.map(space => Object.assign(space, formatSpace(space.id, space.settings)));
+  return spaces.map(space => Object.assign(space, formatSpace(space)));
 }
 
 function checkRelatedSpacesNesting(requestedFields): void {
@@ -276,7 +276,12 @@ export function formatProposal(proposal) {
   if (ts > proposal.start) proposalState = 'active';
   if (ts > proposal.end) proposalState = 'closed';
   proposal.state = proposalState;
-  proposal.space = formatSpace(proposal.space, proposal.settings);
+  proposal.space = formatSpace({
+    id: proposal.space,
+    settings: proposal.settings,
+    verified: proposal.spaceVerified,
+    flagged: proposal.spaceFlagged
+  });
   const networkStr = network === 'testnet' ? 'demo.' : '';
   proposal.link = `https://${networkStr}snapshot.org/#/${proposal.space.id}/proposal/${proposal.id}`;
   proposal.strategies = proposal.strategies.map(strategy => ({
@@ -293,16 +298,31 @@ export function formatVote(vote) {
   vote.choice = jsonParse(vote.choice);
   vote.metadata = jsonParse(vote.metadata, {});
   vote.vp_by_strategy = jsonParse(vote.vp_by_strategy, []);
-  vote.space = formatSpace(vote.space, vote.settings);
+  vote.space = formatSpace({
+    id: vote.space,
+    settings: vote.settings,
+    verified: vote.spaceVerified,
+    flagged: vote.spaceFlagged
+  });
   return vote;
 }
 
 export function formatFollow(follow) {
-  follow.space = formatSpace(follow.space, follow.settings);
+  follow.space = formatSpace({
+    id: follow.space,
+    settings: follow.settings,
+    verified: follow.spaceVerified,
+    flagged: follow.spaceFlagged
+  });
   return follow;
 }
 
 export function formatSubscription(subscription) {
-  subscription.space = formatSpace(subscription.space, subscription.settings);
+  subscription.space = formatSpace({
+    id: subscription.space,
+    settings: subscription.settings,
+    verified: subscription.spaceVerified,
+    flagged: subscription.spaceFlagged
+  });
   return subscription;
 }

--- a/src/graphql/operations/follows.ts
+++ b/src/graphql/operations/follows.ts
@@ -27,7 +27,7 @@ export default async function (parent, args) {
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
 
   const query = `
-    SELECT f.*, spaces.settings FROM follows f
+    SELECT f.*, spaces.settings, spaces.flagged as spaceFlagged, spaces.verified as spaceVerified FROM follows f
     INNER JOIN spaces ON spaces.id = f.space
     WHERE spaces.settings IS NOT NULL ${queryStr}
     ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?

--- a/src/graphql/operations/proposal.ts
+++ b/src/graphql/operations/proposal.ts
@@ -5,7 +5,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export default async function (parent, { id }) {
   const query = `
-    SELECT p.*, spaces.settings FROM proposals p
+    SELECT p.*, spaces.settings, spaces.flagged as spaceFlagged, spaces.verified as spaceVerified FROM proposals p
     INNER JOIN spaces ON spaces.id = p.space
     WHERE p.id = ? AND spaces.settings IS NOT NULL
     LIMIT 1

--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -80,7 +80,7 @@ export default async function (parent, args) {
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
 
   const query = `
-    SELECT p.*, spaces.settings FROM proposals p
+    SELECT p.*, spaces.settings, spaces.flagged as spaceFlagged, spaces.verified as spaceVerified FROM proposals p
     INNER JOIN spaces ON spaces.id = p.space
     WHERE spaces.settings IS NOT NULL ${queryStr} ${searchSql}
     ORDER BY ${orderBy} ${orderDirection}, p.id ASC LIMIT ?, ?

--- a/src/graphql/operations/ranking.ts
+++ b/src/graphql/operations/ranking.ts
@@ -46,7 +46,7 @@ export default async function (_parent, args, context, info) {
       ORDER BY FIELD(s.id, ?) ASC
     `;
     let spaces = await db.queryAsync(query, [filteredSpaces, filteredSpaces]);
-    spaces = spaces.map(space => Object.assign(space, formatSpace(space.id, space.settings)));
+    spaces = spaces.map(space => Object.assign(space, formatSpace(space)));
 
     const items = await handleRelatedSpaces(info, spaces);
 

--- a/src/graphql/operations/subscriptions.ts
+++ b/src/graphql/operations/subscriptions.ts
@@ -29,7 +29,7 @@ export default async function (parent, args) {
   let subscriptions: any[] = [];
 
   const query = `
-    SELECT s.*, spaces.settings FROM subscriptions s
+    SELECT s.*, spaces.settings, spaces.flagged as spaceFlagged, spaces.verified as spaceVerified FROM subscriptions s
     INNER JOIN spaces ON spaces.id = s.space
     WHERE spaces.settings IS NOT NULL ${queryStr}
     ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?

--- a/src/graphql/operations/vote.ts
+++ b/src/graphql/operations/vote.ts
@@ -7,7 +7,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 export default async function (parent, { id }, context, info) {
   const requestedFields = info ? graphqlFields(info) : {};
   const query = `
-    SELECT v.*, spaces.settings FROM votes v
+    SELECT v.*, spaces.settings, spaces.flagged as spaceFlagged, spaces.verified as spaceVerified FROM votes v
     INNER JOIN spaces ON spaces.id = v.space
     WHERE v.id = ? AND spaces.settings IS NOT NULL
     LIMIT 1

--- a/src/graphql/operations/vote.ts
+++ b/src/graphql/operations/vote.ts
@@ -18,7 +18,7 @@ export default async function (parent, { id }, context, info) {
     if (requestedFields.proposal && result?.proposal) {
       const proposalId = result.proposal;
       const query = `
-        SELECT p.*, spaces.settings FROM proposals p
+        SELECT p.*, spaces.settings, spaces.flagged as spaceFlagged, spaces.verified as spaceVerified FROM proposals p
         INNER JOIN spaces ON spaces.id = p.space
         WHERE spaces.settings IS NOT NULL AND p.id = ?
       `;

--- a/src/graphql/operations/votes.ts
+++ b/src/graphql/operations/votes.ts
@@ -55,15 +55,13 @@ async function query(parent, args, context?, info?) {
   if (requestedFields.space && votes.length > 0) {
     const spaceIds = votes.map(vote => vote.space.id).filter((v, i, a) => a.indexOf(v) === i);
     const query = `
-      SELECT id, settings FROM spaces
+      SELECT * FROM spaces
       WHERE id IN (?) AND settings IS NOT NULL AND deleted = 0
     `;
     try {
       let spaces = await db.queryAsync(query, [spaceIds]);
 
-      spaces = Object.fromEntries(
-        spaces.map(space => [space.id, formatSpace(space.id, space.settings)])
-      );
+      spaces = Object.fromEntries(spaces.map(space => [space.id, formatSpace(space)]));
       votes = votes.map(vote => {
         if (spaces[vote.space.id]) return { ...vote, space: spaces[vote.space.id] };
         return vote;

--- a/src/graphql/operations/votes.ts
+++ b/src/graphql/operations/votes.ts
@@ -76,7 +76,7 @@ async function query(parent, args, context?, info?) {
   if (requestedFields.proposal && votes.length > 0) {
     const proposalIds = votes.map(vote => vote.proposal);
     const query = `
-      SELECT p.*, spaces.settings FROM proposals p
+      SELECT p.*, spaces.settings, spaces.flagged as spaceFlagged, spaces.verified as spaceVerified FROM proposals p
       INNER JOIN spaces ON spaces.id = p.space
       WHERE spaces.settings IS NOT NULL AND p.id IN (?)
     `;


### PR DESCRIPTION
## Changes:
- Right now we use, `verified` and `flagged` properties from space data stored in memory
- With this change we use these fields from DB itself


## How to test:
Run following queries:
```GraphQL
{
  votes(first:1000, where:{space:"thanku.eth"}) {
    id
    space{
      id
      verified
      flagged
    }
  }
}
```

```GraphQL
{
  vote(id:"0x461f550ed3422613af414e6d373d62bfda37cd8deb681b6196c7cffb5eed403e"){
    id
    space{
      id
      verified
      flagged
    }
  }
}
```

from `votes` query query with `proposals`, `follows`, `subscribtions` 