### PR TITLE
chore: ensure test suite are only run on test database

### DIFF
--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -15,7 +15,7 @@ const spaceFollowers = {};
 const testnets = Object.values(networks)
   .filter((network: any) => network.testnet)
   .map((network: any) => network.key);
-const testStrategies = ['ticket'];
+const testStrategies = ['ticket', 'api', 'api-v2', 'api-post', 'api-v2-override'];
 
 function getPopularity(
   id: string,

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,9 +1,18 @@
 import { default as db, sequencerDB } from '../src/helpers/mysql';
+import { TEST_DATABASE_SUFFIX } from './setupDb';
 
 const setup = async () => {
   try {
     await db.queryAsync('SELECT 1 + 1');
     await sequencerDB.queryAsync('SELECT 1 + 1');
+
+    if (db.config.connectionConfig.database.endsWith(TEST_DATABASE_SUFFIX)) {
+      throw new Error(`Hub database name is not ending by ${TEST_DATABASE_SUFFIX}`);
+    }
+
+    if (sequencerDB.config.connectionConfig.database.endsWith(TEST_DATABASE_SUFFIX)) {
+      throw new Error(`Sequencer database name is not ending by ${TEST_DATABASE_SUFFIX}`);
+    }
   } catch (e: any) {
     if (e.code === 'ER_BAD_DB_ERROR') {
       console.error('Test database not setup, please run `yarn test:setup`');

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,6 @@
 import { default as db, sequencerDB } from '../src/helpers/mysql';
-import { TEST_DATABASE_SUFFIX } from './setupDb';
+
+export const TEST_DATABASE_SUFFIX = '_test';
 
 const setup = async () => {
   try {

--- a/test/setupDb.ts
+++ b/test/setupDb.ts
@@ -4,8 +4,7 @@ import Connection from 'mysql/lib/Connection';
 import bluebird from 'bluebird';
 import parse from 'connection-string';
 import fs from 'fs';
-
-export const TEST_DATABASE_SUFFIX = '_test';
+import { TEST_DATABASE_SUFFIX } from './setup';
 
 // @ts-ignore
 const config = parse(process.env.HUB_DATABASE_URL);

--- a/test/setupDb.ts
+++ b/test/setupDb.ts
@@ -5,6 +5,8 @@ import bluebird from 'bluebird';
 import parse from 'connection-string';
 import fs from 'fs';
 
+export const TEST_DATABASE_SUFFIX = '_test';
+
 // @ts-ignore
 const config = parse(process.env.HUB_DATABASE_URL);
 config.connectionLimit = 5;
@@ -14,8 +16,8 @@ bluebird.promisifyAll([Pool, Connection]);
 const db = mysql.createPool(config);
 const dbName = config.path[0];
 
-if (!dbName.endsWith('_test')) {
-  console.error('Invalid test database name. Must end with _test');
+if (!dbName.endsWith(TEST_DATABASE_SUFFIX)) {
+  console.error(`Invalid test database name. Must end with ${TEST_DATABASE_SUFFIX}`);
   process.exit(1);
 }
 


### PR DESCRIPTION
This PR add additional securities to ensure test suite are only run on test database.

The convention will be to always prefix test database with `_test`. `yarn test:setup` is provided to automatically setup the test database