### PR TITLE
fix: get `validation` data from DB directly

### DIFF
--- a/src/graphql/operations/validations.ts
+++ b/src/graphql/operations/validations.ts
@@ -1,13 +1,20 @@
-import { spaces } from '../../helpers/spaces';
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import db from '../../helpers/mysql';
 
-export default function () {
-  const validations = {};
-  Object.values(spaces).forEach((space: any) => {
-    if (space.validation)
-      validations[space.validation.name] = (validations[space.validation.name] || 0) + 1;
-  });
-  return Object.entries(validations).map(validation => ({
-    id: validation[0],
-    spacesCount: validation[1]
-  }));
+export default async function () {
+  const query = `
+    SELECT
+      COALESCE(JSON_UNQUOTE(JSON_EXTRACT(settings, '$.validation.name')), '') AS validation,
+      COUNT(id) as spacesCount
+    FROM spaces
+    GROUP BY validation
+    ORDER BY spacesCount DESC
+  `;
+
+  try {
+    return (await db.queryAsync(query)).map(v => ({ ...v, id: v.validation }));
+  } catch (e: any) {
+    capture(e);
+    return Promise.reject(new Error('request failed'));
+  }
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The `validation` query on the hub is using data from space's cache.
This create refresh lag, and dependency on the `space` cache object.

## 💊 Fixes / Solution

Use a SQL query to get validations data from the database

## 🚧 Changes

- Get validations data from the database

## 🛠️ Tests

- Query some validation data from graphql => it should return same results as before
