### PR TITLE
fix: get `strategies` data from DB directly

### DIFF
--- a/src/graphql/operations/strategy.ts
+++ b/src/graphql/operations/strategy.ts
@@ -1,5 +1,5 @@
-import { strategiesObj } from '../../helpers/strategies';
+import { strategies } from '../../helpers/strategies';
 
-export default async function (parent, { id }) {
-  return strategiesObj[id];
+export default function (parent, { id }) {
+  return strategies.find(strategy => strategy.id === id);
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The `strategies` query on the hub is using data from space's cache.
This create refresh lag, and dependency on the `space` cache object.

## 💊 Fixes / Solution

Use a SQL query to get strategies data from the database

## 🚧 Changes

- Get strategies data from the database
- Remove the `strategiesObj` global object. The data can already be queried using a simple `find` on the `strategies`  global variable.

## 🛠️ Tests

- Query some strategies and strategy data from graphql => it should return same results as before
