### PR TITLE
fix: remove unused alias helper

### DIFF
--- a/src/helpers/alias.ts
+++ b/src/helpers/alias.ts
@@ -1,7 +1,0 @@
-import db from './mysql';
-
-export async function isValidAlias(from, alias): Promise<boolean> {
-  const query = 'SELECT * FROM aliases WHERE address = ? AND alias = ? LIMIT 1';
-  const results = await db.queryAsync(query, [from, alias]);
-  return !!results[0];
-}


### PR DESCRIPTION
The file does not seem to be used anywhere, a search on the `isValidAlias` keyword does not yield any results.