### PR TITLE
fix: get `plugins` data from DB directly

### DIFF
--- a/src/graphql/operations/plugins.ts
+++ b/src/graphql/operations/plugins.ts
@@ -1,14 +1,23 @@
-import { spaces } from '../../helpers/spaces';
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import db from '../../helpers/mysql';
 
-export default function () {
-  const plugins = {};
-  Object.values(spaces).forEach((space: any) => {
-    Object.keys(space.plugins || {}).forEach(plugin => {
-      plugins[plugin] = (plugins[plugin] || 0) + 1;
-    });
-  });
-  return Object.entries(plugins).map(network => ({
-    id: network[0],
-    spacesCount: network[1]
-  }));
+export default async function () {
+  const query = `
+    SELECT s.name as id, count(s.name) as spacesCount
+    FROM
+      spaces,
+      JSON_TABLE(
+        JSON_KEYS(settings, '$.plugins'),
+        '$[*]' COLUMNS (name VARCHAR(255)  PATH '$')
+      ) s
+    GROUP BY s.name
+    ORDER BY spacesCount DESC;
+  `;
+
+  try {
+    return await db.queryAsync(query);
+  } catch (e: any) {
+    capture(e);
+    return Promise.reject(new Error('request failed'));
+  }
 }


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/544

## 🧿 Current issues / What's wrong ?

The `plugins` query on the hub is using data from space's cache.
This create refresh lag, and dependency on the `space` cache object.

## 💊 Fixes / Solution

Use a SQL query to get plugins data from the database

## 🚧 Changes

- Get plugins data from the database

## 🛠️ Tests

- Query some plugin data from graphql => it should return same results as before
