### PR TITLE
fix: get `network` data from DB directly

### DIFF
--- a/src/graphql/operations/networks.ts
+++ b/src/graphql/operations/networks.ts
@@ -1,12 +1,20 @@
-import { spaces } from '../../helpers/spaces';
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import db from '../../helpers/mysql';
 
-export default function () {
-  const networks = {};
-  Object.values(spaces).forEach((space: any) => {
-    networks[space.network] = networks[space.network] ? networks[space.network] + 1 : 1;
-  });
-  return Object.entries(networks).map(network => ({
-    id: network[0],
-    spacesCount: network[1]
-  }));
+export default async function () {
+  const query = `
+    SELECT
+      JSON_UNQUOTE(JSON_EXTRACT(settings, '$.network')) as network,
+      COUNT(name) AS spacesCount
+    FROM spaces
+    GROUP BY network
+    ORDER BY spacesCount DESC;
+  `;
+
+  try {
+    return (await db.queryAsync(query)).map(v => ({ ...v, id: v.network }));
+  } catch (e: any) {
+    capture(e);
+    return Promise.reject(new Error('request failed'));
+  }
 }

--- a/src/graphql/operations/networks.ts
+++ b/src/graphql/operations/networks.ts
@@ -1,18 +1,28 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import db from '../../helpers/mysql';
 
 export default async function () {
   const query = `
     SELECT
       JSON_UNQUOTE(JSON_EXTRACT(settings, '$.network')) as network,
-      COUNT(name) AS spacesCount
+      COUNT(name) AS count
     FROM spaces
     GROUP BY network
-    ORDER BY spacesCount DESC;
+    ORDER BY count DESC;
   `;
 
   try {
-    return (await db.queryAsync(query)).map(v => ({ ...v, id: v.network }));
+    const results = new Map(await db.queryAsync(query).map(r => [r.network, r.count]));
+
+    return Object.values(networks)
+      .map((network: any) => {
+        network.id = network.key;
+        network.spacesCount = results.get(network.id) || 0;
+        network.testnet ||= false;
+        return network;
+      })
+      .sort((a, b) => b.spacesCount - a.spacesCount);
   } catch (e: any) {
     capture(e);
     return Promise.reject(new Error('request failed'));

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -89,7 +89,7 @@ type Query {
 
   skins: [Item]
 
-  networks: [Item]
+  networks: [Network]
 
   validations: [Item]
 
@@ -554,4 +554,21 @@ type Vp {
   vp: Float
   vp_by_strategy: [Float]
   vp_state: String
+}
+
+type Network {
+  key: String
+  id: String
+  spacesCount: Int
+  name: String
+  chainId: String
+  network: String
+  explorer: NetworkExplorer
+  logo: String
+  testnet: Boolean
+}
+
+type NetworkExplorer {
+  url: String
+  apiUrl: String
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The `network` query on the hub is using data from space's cache.
This create refresh lag, and dependency on the `space` cache object.

## 💊 Fixes / Solution

Use a SQL query to get networks count data from the database, and return more network properties, allowing queries like:

```graphql
query Networks {
  networks {
    key
    id
    spacesCount
    name
    chainId
    network
    explorer {
      url
      apiUrl
    }
    logo
    testnet
  }
}
```

## 🚧 Changes

- Get networks count data from the database instead of space's cache
- Return more fields from networks.json. Not all fields from networks.json are returned, only the one used by the snapshot UI.

## 🛠️ Tests

- Query some network data from graphql => it should return same results as before, in addition to the new fields
