### PR TITLE
fix: fix space query unable to get past 30k spaces

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -154,7 +154,7 @@ export function buildWhereQuery(fields, alias, where) {
 export async function fetchSpaces(args) {
   const { first = 20, skip = 0, where = {} } = args;
 
-  const fields = { id: 'string' };
+  const fields = { id: 'string', created_at: 'number' };
   const whereQuery = buildWhereQuery(fields, 's', where);
   const queryStr = whereQuery.query;
   const params: any[] = whereQuery.params;

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -154,7 +154,7 @@ export function buildWhereQuery(fields, alias, where) {
 export async function fetchSpaces(args) {
   const { first = 20, skip = 0, where = {} } = args;
 
-  const fields = { id: 'string', created_at: 'number' };
+  const fields = { id: 'string', created: 'number' };
   const whereQuery = buildWhereQuery(fields, 's', where);
   const queryStr = whereQuery.query;
   const params: any[] = whereQuery.params;

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -117,12 +117,12 @@ type Query {
 input SpaceWhere {
   id: String
   id_in: [String]
-  created_at: Int
-  created_at_in: [Int]
-  created_at_gt: Int
-  created_at_gte: Int
-  created_at_lt: Int
-  created_at_lte: Int
+  created: Int
+  created_in: [Int]
+  created_gt: Int
+  created_gte: Int
+  created_lt: Int
+  created_lte: Int
 }
 
 input RankingWhere {
@@ -391,7 +391,7 @@ type Space {
   verified: Boolean
   flagged: Boolean
   rank: Float
-  created_at: Int!
+  created: Int!
 }
 
 type RankingObject {

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -117,6 +117,12 @@ type Query {
 input SpaceWhere {
   id: String
   id_in: [String]
+  created_at: Int
+  created_at_in: [Int]
+  created_at_gt: Int
+  created_at_gte: Int
+  created_at_lt: Int
+  created_at_lte: Int
 }
 
 input RankingWhere {
@@ -385,6 +391,7 @@ type Space {
   verified: Boolean
   flagged: Boolean
   rank: Float
+  created_at: Int!
 }
 
 type RankingObject {


### PR DESCRIPTION
Fix #714 

We're limiting the space to 30k, which is a hard limit, since the Space query does not provided any filters to paginate.

This PR adds a `created` filter in where, to enable paginating the Space object, like the Vote object.

This enable query like 

```graphql
query Spaces {
  spaces(first: 10, skip: 5, where: {created_gt: 1697661410}) {
    name
    created
  }
}
```