### PR TITLE
fix: skip logging graphQl Errors

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -1,7 +1,7 @@
 import init, { client } from '@snapshot-labs/snapshot-metrics';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { Express, type Request, type Response } from 'express';
-import { parse } from 'graphql';
+import { GraphQLError, parse } from 'graphql';
 import { spacesMetadata } from './spaces';
 import { strategies } from './strategies';
 import db from './mysql';
@@ -71,7 +71,9 @@ export default function initMetrics(app: Express) {
             }
           }
         } catch (e: any) {
-          capture(e);
+          if (!(e instanceof GraphQLError)) {
+            capture(e);
+          }
         }
       });
     }

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -58,8 +58,12 @@ export default function initMetrics(app: Express) {
           if (query && operationName) {
             const definition = parse(query).definitions.find(
               // @ts-ignore
-              def => def.name.value === operationName
+              def => def.name?.value === operationName
             );
+
+            if (!definition) {
+              return;
+            }
 
             // @ts-ignore
             const types = definition.selectionSet.selections.map(sel => sel.name.value);

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -58,12 +58,8 @@ export default function initMetrics(app: Express) {
           if (query && operationName) {
             const definition = parse(query).definitions.find(
               // @ts-ignore
-              def => def.name?.value === operationName
+              def => def.name.value === operationName
             );
-
-            if (!definition) {
-              return;
-            }
 
             // @ts-ignore
             const types = definition.selectionSet.selections.map(sel => sel.name.value);


### PR DESCRIPTION
Fix #727 
Fix [SNAPSHOT-HUB-19](https://snapshot-labs.sentry.io/issues/4545184002/?referrer=github_integration)

Stop logging graphql syntax errors from the metrics middleware
