### PR TITLE
fix: check for value before manipulation

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -58,8 +58,12 @@ export default function initMetrics(app: Express) {
           if (query && operationName) {
             const definition = parse(query).definitions.find(
               // @ts-ignore
-              def => def.name.value === operationName
+              def => def.name?.value === operationName
             );
+
+            if (!definition) {
+              return;
+            }
 
             // @ts-ignore
             const types = definition.selectionSet.selections.map(sel => sel.name.value);


### PR DESCRIPTION
Fix #729
Fix SNAPSHOT-HUB-1D
Fix SNAPSHOT-HUB-1B

Check that value is defined before usage