### PR TITLE
refactor: trigger data refresher manually

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,14 +1,12 @@
 import express from 'express';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import refreshSpacesCache, { getSpace } from './helpers/spaces';
+import { getSpace } from './helpers/spaces';
 import { name, version } from '../package.json';
 import { sendError } from './helpers/utils';
 
 const router = express.Router();
 const network = process.env.NETWORK || 'testnet';
 const SEQUENCER_URL = process.env.SEQUENCER_URL || '';
-
-refreshSpacesCache();
 
 router.post('/message', async (req, res) => {
   return sendError(res, 'personal sign is not supported anymore');

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,12 +1,14 @@
 import express from 'express';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { getSpace } from './helpers/spaces';
+import refreshSpacesCache, { getSpace } from './helpers/spaces';
 import { name, version } from '../package.json';
 import { sendError } from './helpers/utils';
 
 const router = express.Router();
 const network = process.env.NETWORK || 'testnet';
 const SEQUENCER_URL = process.env.SEQUENCER_URL || '';
+
+refreshSpacesCache();
 
 router.post('/message', async (req, res) => {
   return sendError(res, 'personal sign is not supported anymore');

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -58,8 +58,12 @@ export default function initMetrics(app: Express) {
           if (query && operationName) {
             const definition = parse(query).definitions.find(
               // @ts-ignore
-              def => def.name.value === operationName
+              def => def.name?.value === operationName
             );
+
+            if (!definition) {
+              return;
+            }
 
             // @ts-ignore
             const types = definition.selectionSet.selections.map(sel => sel.name.value);

--- a/src/helpers/moderation.ts
+++ b/src/helpers/moderation.ts
@@ -13,7 +13,7 @@ async function loadModerationData() {
   flaggedLinks = res?.flaggedLinks;
 }
 
-async function run() {
+export default async function run() {
   try {
     await loadModerationData();
     consecutiveFailsCount = 0;
@@ -28,5 +28,3 @@ async function run() {
   await snapshot.utils.sleep(5e3);
   run();
 }
-
-run();

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -176,7 +176,7 @@ export async function getSpace(id: string) {
   };
 }
 
-async function run() {
+export default async function run() {
   try {
     await loadSpaces();
     await loadSpacesMetrics();
@@ -187,5 +187,3 @@ async function run() {
   await snapshot.utils.sleep(360e3);
   run();
 }
-
-run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import log from './helpers/log';
 import initMetrics from './helpers/metrics';
 import { checkKeycard } from './helpers/keycard';
 import refreshModerationData from './helpers/moderation';
+import refreshSpacesCache from './helpers/spaces';
 import './helpers/strategies';
 
 const app = express();
@@ -17,6 +18,7 @@ const PORT = process.env.PORT || 3000;
 initLogger(app);
 initMetrics(app);
 refreshModerationData();
+refreshSpacesCache();
 
 app.disable('x-powered-by');
 app.use(express.json({ limit: '20mb' }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import rateLimit from './helpers/rateLimit';
 import log from './helpers/log';
 import initMetrics from './helpers/metrics';
 import { checkKeycard } from './helpers/keycard';
-import './helpers/moderation';
+import refreshModerationData from './helpers/moderation';
 import './helpers/strategies';
 
 const app = express();
@@ -16,6 +16,7 @@ const PORT = process.env.PORT || 3000;
 
 initLogger(app);
 initMetrics(app);
+refreshModerationData();
 
 app.disable('x-powered-by');
 app.use(express.json({ limit: '20mb' }));


### PR DESCRIPTION
Extracted from #712 

Trigger the space and moderation data refresher manually, instead of automatically on import.

This allow skipping the refresh, and is particularly useful on test suite