### PR TITLE
fix: return an error on invalid voter address

### DIFF
--- a/src/graphql/operations/vp.ts
+++ b/src/graphql/operations/vp.ts
@@ -4,6 +4,10 @@ import db from '../../helpers/mysql';
 const scoreAPIUrl = process.env.SCORE_API_URL || 'https://score.snapshot.org';
 
 export default async function (_parent, { voter, space, proposal }) {
+  if (voter === '0x0000000000000000000000000000000000000000' || voter === '') {
+    return Promise.reject(new Error('invalid address'));
+  }
+
   if (proposal) {
     const query = `SELECT * FROM proposals WHERE id = ?`;
     const [p] = await db.queryAsync(query, [proposal]);


### PR DESCRIPTION
Fail early and return meaningful when voter address is invalid on `vp` query

Before, when passing `0x0000000000000000000000000000000000000000` or `` as voter, it calls score-api then returns:

```
{
  "errors": [
    {
      "message": "Unexpected error value: { code: 400, message: \"unauthorized\", data: \"invalid address\" }",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "vp"
      ]
    }
  ],
  "data": {
    "vp": null
  }
}
```

Now, it should return the error without calling score-api

```
{
  "errors": [
    {
      "message": "invalid address",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "vp"
      ]
    }
  ],
  "data": {
    "vp": null
  }
}
```

Test with following query

```
query Vp{
		vp(
			space: "rocketpool-dao.eth",
			voter: "0x0000000000000000000000000000000000000000",
		) {
			vp
		}
	}
	
```