### PR TITLE
fix: check space and proposal exist

### DIFF
--- a/src/graphql/operations/vp.ts
+++ b/src/graphql/operations/vp.ts
@@ -5,8 +5,12 @@ const scoreAPIUrl = process.env.SCORE_API_URL || 'https://score.snapshot.org';
 
 export default async function (_parent, { voter, space, proposal }) {
   if (proposal) {
-    const query = `SELECT * FROM proposals WHERE id = ?`;
+    const query = `SELECT * FROM proposals WHERE id = ? LIMIT 1`;
     const [p] = await db.queryAsync(query, [proposal]);
+
+    if (!p) {
+      return Promise.reject(new Error('proposal not found'));
+    }
 
     return await snapshot.utils.getVp(
       voter,
@@ -20,6 +24,11 @@ export default async function (_parent, { voter, space, proposal }) {
   } else if (space) {
     const query = `SELECT settings FROM spaces WHERE id = ? AND deleted = 0 LIMIT 1`;
     let [s] = await db.queryAsync(query, [space]);
+
+    if (!s) {
+      return Promise.reject(new Error('space not found'));
+    }
+
     s = JSON.parse(s.settings);
 
     return await snapshot.utils.getVp(voter, s.network, s.strategies, 'latest', space, false, {


### PR DESCRIPTION
in `vp` operation, check that proposal and space exist, and return meaningful error otherwise.

With this test query 

```
query Vp{
		vp(
			space: "rocketposfsdfol-dao.eth",
      proposal: "asas",
			voter: "0x0000000000000000000000000000000000000000",
		) {
			vp
		}
	}
	
```

Before fix, it returns 

```
{
  "errors": [
    {
      "message": "Cannot read properties of undefined (reading 'network')",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "vp"
      ]
    }
  ],
  "data": {
    "vp": null
  }
}
```

After fix, it returns

```
{
  "errors": [
    {
      "message": "space not found",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "vp"
      ]
    }
  ],
  "data": {
    "vp": null
  }
}
```