### PR TITLE
fix: rename `_at` suffix from Space timestamp properties

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -159,9 +159,9 @@ export async function fetchSpaces(args) {
   const queryStr = whereQuery.query;
   const params: any[] = whereQuery.params;
 
-  let orderBy = args.orderBy || 'created_at';
+  let orderBy = args.orderBy || 'created';
   let orderDirection = args.orderDirection || 'desc';
-  if (!['created_at', 'updated_at', 'id'].includes(orderBy)) orderBy = 'created_at';
+  if (!['created', 'updated_at', 'id'].includes(orderBy)) orderBy = 'created';
   orderDirection = orderDirection.toUpperCase();
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
 

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -161,7 +161,7 @@ export async function fetchSpaces(args) {
 
   let orderBy = args.orderBy || 'created';
   let orderDirection = args.orderDirection || 'desc';
-  if (!['created', 'updated_at', 'id'].includes(orderBy)) orderBy = 'created';
+  if (!['created', 'updated', 'id'].includes(orderBy)) orderBy = 'created';
   orderDirection = orderDirection.toUpperCase();
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
 

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -6,14 +6,14 @@ CREATE TABLE spaces (
   deleted INT NOT NULL DEFAULT '0',
   flagged INT NOT NULL DEFAULT '0',
   created BIGINT NOT NULL,
-  updated_at BIGINT NOT NULL,
+  updated BIGINT NOT NULL,
   PRIMARY KEY (id),
   INDEX name (name),
   INDEX verified (verified),
   INDEX flagged (flagged),
   INDEX deleted (deleted),
   INDEX created (created),
-  INDEX updated_at (updated_at)
+  INDEX updated (updated)
 );
 
 CREATE TABLE proposals (

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -5,14 +5,14 @@ CREATE TABLE spaces (
   verified INT NOT NULL DEFAULT '0',
   deleted INT NOT NULL DEFAULT '0',
   flagged INT NOT NULL DEFAULT '0',
-  created_at BIGINT NOT NULL,
+  created BIGINT NOT NULL,
   updated_at BIGINT NOT NULL,
   PRIMARY KEY (id),
   INDEX name (name),
   INDEX verified (verified),
   INDEX flagged (flagged),
   INDEX deleted (deleted),
-  INDEX created_at (created_at),
+  INDEX created (created),
   INDEX updated_at (updated_at)
 );
 

--- a/test/fixtures/spaces.ts
+++ b/test/fixtures/spaces.ts
@@ -6,7 +6,7 @@ const fixtures: Record<string, any>[] = [
     verified: true,
     settings: { network: 1 },
     created: Math.floor(Date.now() / 1e3),
-    updated_at: Math.floor(Date.now() / 1e3)
+    updated: Math.floor(Date.now() / 1e3)
   }
 ];
 

--- a/test/fixtures/spaces.ts
+++ b/test/fixtures/spaces.ts
@@ -5,7 +5,7 @@ const fixtures: Record<string, any>[] = [
     flagged: false,
     verified: true,
     settings: { network: 1 },
-    created_at: Math.floor(Date.now() / 1e3),
+    created: Math.floor(Date.now() / 1e3),
     updated_at: Math.floor(Date.now() / 1e3)
   }
 ];


### PR DESCRIPTION
Ref to #726 

Rename the `created_at` and `updated_at` properties in Space to just `created` and `updated`, to be consistent with the all the other objects.

Run the following query 

```sql
ALTER TABLE spaces RENAME COLUMN created_at TO created;
ALTER TABLE spaces RENAME INDEX created_at TO created;

ALTER TABLE spaces RENAME COLUMN updated_at TO updated;
ALTER TABLE spaces RENAME INDEX updated_at TO updated;
```