### PR TITLE
fix: Remove confusing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ yarn start
 }
 ```
 
-## Usage
-
-Once your hub is running online, the main hub can relay the messages received to your own hub. Please provide the URL of your Snapshot hub to an admin to make sure it's connected to the network.
-
 ### Load a space setting
 
 To load a space settings in the database you can go on this endpoint http://localhost:3000/api/spaces/yam.eth/poke (change yam.eth with the space you want to activate).


### PR DESCRIPTION
the text is confusing, someone using hub doesn't have to provide URL to us, it should run individually 