### PR TITLE
Fix: Exclude flagged proposals from active proposals count

### DIFF
--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -113,7 +113,7 @@ async function getProposals() {
   const ts = parseInt((Date.now() / 1e3).toFixed());
   const query = `
     SELECT space, COUNT(id) AS count,
-    COUNT(IF(start < ? AND end > ?, 1, NULL)) AS active,
+    COUNT(IF(start < ? AND end > ? AND flagged = 0, 1, NULL)) AS active,
     count(IF(created > (UNIX_TIMESTAMP() - 604800), 1, NULL)) as count_7d
     FROM proposals GROUP BY space
   `;


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/pitches/issues/47


How to test:
- Create a test proposal on your space, `activeProposals` on `Space` query should return `1`
- Mark proposal as flagged
- Count should be `0`