### PR TITLE
fix: empty array in graphql filters should trigger an error

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -102,6 +102,7 @@ export function formatSpace({ id, settings, verified, flagged, hibernated }) {
 export function buildWhereQuery(fields, alias, where) {
   let query: any = '';
   const params: any[] = [];
+
   Object.entries(fields).forEach(([field, type]) => {
     if (where[field] !== undefined) {
       query += `AND ${alias}.${field} = ? `;
@@ -114,16 +115,24 @@ export function buildWhereQuery(fields, alias, where) {
       params.push(fieldNot);
     }
 
-    const fieldIn = where[`${field}_in`] || [];
-    if (fieldIn.length > 0) {
-      query += `AND ${alias}.${field} IN (?) `;
-      params.push(fieldIn);
+    const fieldIn = where[`${field}_in`];
+    if (Array.isArray(fieldIn)) {
+      if (fieldIn.length > 0) {
+        query += `AND ${alias}.${field} IN (?) `;
+        params.push(fieldIn);
+      } else {
+        throw new PublicError(`${field}_in must have at least one item`);
+      }
     }
 
-    const fieldNotIn = where[`${field}_not_in`] || [];
-    if (fieldNotIn.length > 0) {
-      query += `AND ${alias}.${field} NOT IN (?) `;
-      params.push(fieldNotIn);
+    const fieldNotIn = where[`${field}_not_in`];
+    if (Array.isArray(fieldNotIn)) {
+      if (fieldNotIn?.length > 0) {
+        query += `AND ${alias}.${field} NOT IN (?) `;
+        params.push(fieldNotIn);
+      } else {
+        throw new PublicError(`${field}_not_in must have at least one item`);
+      }
     }
 
     if (type === 'number') {

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -42,6 +42,13 @@ export function checkLimits(args: any = {}, type) {
       throw new PublicError(`The \`${key}\` argument must be positive`);
     }
   }
+
+  Object.keys(where).forEach(key => {
+    if (key.endsWith('_in') && where[key].length === 0) {
+      throw new PublicError(`${key} must have at least one item`);
+    }
+  });
+
   return true;
 }
 

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -36,10 +36,10 @@ export function checkLimits(args: any = {}, type) {
     const skipLimitReached = key === 'skip' && args[key] > limit;
     const whereLimitReached = key.endsWith('_in') ? where[key]?.length > limit : where[key] > limit;
     if (firstLimitReached || skipLimitReached || whereLimitReached)
-      throw new Error(`The \`${key}\` argument must not be greater than ${limit}`);
+      throw new PublicError(`The \`${key}\` argument must not be greater than ${limit}`);
 
     if (['first', 'skip'].includes(key) && args[key] < 0) {
-      throw new Error(`The \`${key}\` argument must be positive`);
+      throw new PublicError(`The \`${key}\` argument must be positive`);
     }
   }
   return true;

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -102,7 +102,6 @@ export function formatSpace({ id, settings, verified, flagged, hibernated }) {
 export function buildWhereQuery(fields, alias, where) {
   let query: any = '';
   const params: any[] = [];
-
   Object.entries(fields).forEach(([field, type]) => {
     if (where[field] !== undefined) {
       query += `AND ${alias}.${field} = ? `;
@@ -115,24 +114,16 @@ export function buildWhereQuery(fields, alias, where) {
       params.push(fieldNot);
     }
 
-    const fieldIn = where[`${field}_in`];
-    if (Array.isArray(fieldIn)) {
-      if (fieldIn.length > 0) {
-        query += `AND ${alias}.${field} IN (?) `;
-        params.push(fieldIn);
-      } else {
-        throw new PublicError(`${field}_in must have at least one item`);
-      }
+    const fieldIn = where[`${field}_in`] || [];
+    if (fieldIn.length > 0) {
+      query += `AND ${alias}.${field} IN (?) `;
+      params.push(fieldIn);
     }
 
-    const fieldNotIn = where[`${field}_not_in`];
-    if (Array.isArray(fieldNotIn)) {
-      if (fieldNotIn?.length > 0) {
-        query += `AND ${alias}.${field} NOT IN (?) `;
-        params.push(fieldNotIn);
-      } else {
-        throw new PublicError(`${field}_not_in must have at least one item`);
-      }
+    const fieldNotIn = where[`${field}_not_in`] || [];
+    if (fieldNotIn.length > 0) {
+      query += `AND ${alias}.${field} NOT IN (?) `;
+      params.push(fieldNotIn);
     }
 
     if (type === 'number') {


### PR DESCRIPTION
Fixes #757 

GraphQL filters with empty array now return an error, like on https://api.lens.dev/graphql

Test with 

```graphql
query Spaces {
  spaces(first: 5, skip: 0, where: {id_in: []}) {
    name
    created
  }
}

```

Should return 

```json
{
  "errors": [
    {
      "message": "id_in must have at least one item",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "spaces"
      ]
    }
  ],
  "data": {
    "spaces": null
  }
}
```

Additionally, move all `throw new Error` to `throw new PulbicError` for consistency