### PR TITLE
Revert "fix: empty array in graphql filters should trigger an error"

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -36,19 +36,12 @@ export function checkLimits(args: any = {}, type) {
     const skipLimitReached = key === 'skip' && args[key] > limit;
     const whereLimitReached = key.endsWith('_in') ? where[key]?.length > limit : where[key] > limit;
     if (firstLimitReached || skipLimitReached || whereLimitReached)
-      throw new PublicError(`The \`${key}\` argument must not be greater than ${limit}`);
+      throw new Error(`The \`${key}\` argument must not be greater than ${limit}`);
 
     if (['first', 'skip'].includes(key) && args[key] < 0) {
-      throw new PublicError(`The \`${key}\` argument must be positive`);
+      throw new Error(`The \`${key}\` argument must be positive`);
     }
   }
-
-  Object.keys(where).forEach(key => {
-    if (key.endsWith('_in') && where[key].length === 0) {
-      throw new PublicError(`${key} must have at least one item`);
-    }
-  });
-
   return true;
 }
 


### PR DESCRIPTION
Reverts snapshot-labs/snapshot-hub#763

Looks like UI still send empty array sometimes, we need to fix those first 

For example in proposals page
https://discord.com/channels/707079246388133940/1090304570015629365/1179358781788913674