### PR TITLE
chore: add turbo param for spaces

### DIFF
--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -391,6 +391,7 @@ type Space {
   verified: Boolean
   flagged: Boolean
   hibernated: Boolean
+  turbo: Boolean
   rank: Float
   created: Int!
 }

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE spaces (
   deleted INT NOT NULL DEFAULT '0',
   flagged INT NOT NULL DEFAULT '0',
   hibernated INT NOT NULL DEFAULT '0',
+  turbo INT NOT NULL DEFAULT '0',
   created BIGINT NOT NULL,
   updated BIGINT NOT NULL,
   PRIMARY KEY (id),
@@ -13,6 +14,7 @@ CREATE TABLE spaces (
   INDEX verified (verified),
   INDEX flagged (flagged),
   INDEX hibernated (hibernated),
+  INDEX turbo (turbo),
   INDEX deleted (deleted),
   INDEX created (created),
   INDEX updated (updated)


### PR DESCRIPTION
The field is already added in the testnet and livenet db. This will be used to grant additional permission or advantages for spaces. 