### PR TITLE
fix: update test site subdomain to `testnet`

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -293,7 +293,7 @@ export function formatProposal(proposal) {
     flagged: proposal.spaceFlagged,
     hibernated: proposal.spaceHibernated
   });
-  const networkStr = network === 'testnet' ? 'demo.' : '';
+  const networkStr = network === 'testnet' ? 'testnet.' : '';
   proposal.link = `https://${networkStr}snapshot.org/#/${proposal.space.id}/proposal/${proposal.id}`;
   proposal.strategies = proposal.strategies.map(strategy => ({
     ...strategy,


### PR DESCRIPTION
demo.snapshot.org has been renamed to testnet.snapshot.org
