### PR TITLE
fix: SQL query to get space is missing turbo field

### DIFF
--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -106,7 +106,7 @@ function mapSpaces() {
 
 async function loadSpaces() {
   const query =
-    'SELECT id, settings, flagged, verified, hibernated FROM spaces WHERE deleted = 0 ORDER BY id ASC';
+    'SELECT id, settings, flagged, verified, turbo, hibernated FROM spaces WHERE deleted = 0 ORDER BY id ASC';
   const s = await db.queryAsync(query);
   spaces = Object.fromEntries(
     s.map(ensSpace => [
@@ -179,7 +179,7 @@ async function loadSpacesMetrics() {
 
 export async function getSpace(id: string) {
   const query = `
-    SELECT settings, flagged, verified
+    SELECT settings, flagged, verified, turbo, hibernated
     FROM spaces
     WHERE deleted = 0 AND id = ?
     LIMIT 1`;
@@ -191,7 +191,9 @@ export async function getSpace(id: string) {
   return {
     ...JSON.parse(space.settings),
     flagged: space.flagged === 1,
-    verified: space.verified === 1
+    verified: space.verified === 1,
+    turbo: space.turbo === 1,
+    hibernated: space.hibernated === 1
   };
 }
 

--- a/test/e2e/space.test.ts
+++ b/test/e2e/space.test.ts
@@ -40,6 +40,8 @@ describe('GET /api/space/:key', () => {
       const expectedSpace = {
         flagged: space.flagged,
         verified: space.verified,
+        turbo: space.turbo,
+        hibernated: space.hibernated,
         ...space.settings
       };
 

--- a/test/fixtures/spaces.ts
+++ b/test/fixtures/spaces.ts
@@ -4,6 +4,8 @@ const fixtures: Record<string, any>[] = [
     name: 'Fabien.eth',
     flagged: false,
     verified: true,
+    turbo: false,
+    hibernated: false,
     settings: { network: 1 },
     created: Math.floor(Date.now() / 1e3),
     updated: Math.floor(Date.now() / 1e3)


### PR DESCRIPTION
`loadSpaces` is missing turbo field so it is unable to calculate ranking of turbo spaces 