### PR TITLE
fix: fix error when passing `null` to `skip` and `first` arg

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -174,7 +174,7 @@ export function buildWhereQuery(fields, alias, where) {
 }
 
 export async function fetchSpaces(args) {
-  const { first = 20, skip = 0, where = {} } = args;
+  const { first, skip, where = {} } = args;
 
   const fields = { id: 'string', created: 'number' };
   const whereQuery = buildWhereQuery(fields, 's', where);

--- a/src/graphql/operations/aliases.ts
+++ b/src/graphql/operations/aliases.ts
@@ -4,7 +4,7 @@ import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export default async function (parent, args) {
-  const { first = 20, skip = 0, where = {} } = args;
+  const { first, skip, where = {} } = args;
 
   checkLimits(args, 'aliases');
 

--- a/src/graphql/operations/follows.ts
+++ b/src/graphql/operations/follows.ts
@@ -4,7 +4,7 @@ import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export default async function (parent, args) {
-  const { first = 20, skip = 0, where = {} } = args;
+  const { first, skip, where = {} } = args;
 
   checkLimits(args, 'follows');
 

--- a/src/graphql/operations/messages.ts
+++ b/src/graphql/operations/messages.ts
@@ -4,7 +4,7 @@ import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export default async function (parent, args) {
-  const { first = 20, skip = 0, where = {} } = args;
+  const { first, skip, where = {} } = args;
 
   checkLimits(args, 'messages');
 

--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -4,7 +4,7 @@ import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export default async function (parent, args) {
-  const { first = 20, skip = 0, where = {} } = args;
+  const { first, skip, where = {} } = args;
 
   checkLimits(args, 'proposals');
 

--- a/src/graphql/operations/ranking.ts
+++ b/src/graphql/operations/ranking.ts
@@ -12,7 +12,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 export default async function (_parent, args, context, info) {
   checkLimits(args, 'ranking');
   try {
-    const { first = 20, skip = 0, where = {} } = args;
+    const { first, skip, where = {} } = args;
 
     const metrics: { total: number; categories: any } = {
       total: 0,

--- a/src/graphql/operations/statements.ts
+++ b/src/graphql/operations/statements.ts
@@ -4,7 +4,7 @@ import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export default async function (parent, args) {
-  const { first = 20, skip = 0, where = {} } = args;
+  const { first, skip, where = {} } = args;
 
   checkLimits(args, 'statements');
 

--- a/src/graphql/operations/subscriptions.ts
+++ b/src/graphql/operations/subscriptions.ts
@@ -4,7 +4,7 @@ import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export default async function (parent, args) {
-  const { first = 20, skip = 0, where = {} } = args;
+  const { first, skip, where = {} } = args;
 
   checkLimits(args, 'subscriptions');
 

--- a/src/graphql/operations/users.ts
+++ b/src/graphql/operations/users.ts
@@ -4,7 +4,7 @@ import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export default async function (parent, args) {
-  const { first = 20, skip = 0, where = {} } = args;
+  const { first, skip, where = {} } = args;
 
   checkLimits(args, 'users');
 

--- a/src/graphql/operations/votes.ts
+++ b/src/graphql/operations/votes.ts
@@ -13,7 +13,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 
 async function query(parent, args, context?, info?) {
   const requestedFields = info ? graphqlFields(info) : {};
-  const { where = {}, first = 20, skip = 0 } = args;
+  const { first, skip, where = {} } = args;
 
   checkLimits(args, 'votes');
 

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -6,24 +6,20 @@ type Query {
   space(id: String): Space
 
   spaces(
-    first: Int
-    skip: Int
+    first: Int! = 20
+    skip: Int! = 0
     where: SpaceWhere
     orderBy: String
     orderDirection: OrderDirection
   ): [Space]
 
-  ranking(
-    first: Int
-    skip: Int
-    where: RankingWhere
-  ): RankingObject
+  ranking(first: Int! = 20, skip: Int! = 0, where: RankingWhere): RankingObject
 
   proposal(id: String): Proposal
 
   proposals(
-    first: Int
-    skip: Int
+    first: Int! = 20
+    skip: Int! = 0
     where: ProposalWhere
     orderBy: String
     orderDirection: OrderDirection
@@ -32,52 +28,50 @@ type Query {
   vote(id: String): Vote
 
   votes(
-    first: Int
-    skip: Int
+    first: Int! = 20
+    skip: Int! = 0
     where: VoteWhere
     orderBy: String
     orderDirection: OrderDirection
   ): [Vote]
 
   aliases(
-    first: Int
-    skip: Int
+    first: Int! = 20
+    skip: Int! = 0
     where: AliasWhere
     orderBy: String
     orderDirection: OrderDirection
   ): [Alias]
 
-  roles(
-    where: RolesWhere
-  ): [Role]
+  roles(where: RolesWhere): [Role]
 
   follows(
-    first: Int
-    skip: Int
+    first: Int! = 20
+    skip: Int! = 0
     where: FollowWhere
     orderBy: String
     orderDirection: OrderDirection
   ): [Follow]
 
   subscriptions(
-    first: Int
-    skip: Int
+    first: Int! = 20
+    skip: Int! = 0
     where: SubscriptionWhere
     orderBy: String
     orderDirection: OrderDirection
   ): [Subscription]
 
   users(
-    first: Int
-    skip: Int
+    first: Int! = 20
+    skip: Int! = 0
     where: UsersWhere
     orderBy: String
     orderDirection: OrderDirection
   ): [User]
 
   statements(
-    first: Int
-    skip: Int
+    first: Int! = 20
+    skip: Int! = 0
     where: StatementsWhere
     orderBy: String
     orderDirection: OrderDirection
@@ -99,15 +93,11 @@ type Query {
 
   strategy(id: String): StrategyItem
 
-  vp(
-    voter: String!
-    space: String!
-    proposal: String
-  ): Vp
+  vp(voter: String!, space: String!, proposal: String): Vp
 
   messages(
-    first: Int
-    skip: Int
+    first: Int! = 20
+    skip: Int! = 0
     where: MessageWhere
     orderBy: String
     orderDirection: OrderDirection


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The graphql schema is allowing query like this

```
query Proposals {
  proposals(
    first: 10,
    skip: null
  ) {
    id
  }
}
```

Where `first` and `skip` can both be null, due to usage of `Int`

This query trigger an SQL error, since it's interpreted as `ORDER BY xx ASC NULL, NULL`
 
## 💊 Fixes / Solution

Disallow usage of `null` on `skip` and `first` argument, and only accept number

Fix #783 
Fix [SNAPSHOT-HUB-1V](https://snapshot-labs.sentry.io/issues/4833242289/?referrer=github_integration)

## 🚧 Changes

- Enforce default value for `skip` and `first` on the schema level
- Remove default value on resolvers function

## 🛠️ Tests

Passing following query should not fail anymore, and should trigger a validation error instead

```
query Proposals {
  proposals(
    first: 10,
    skip: null
  ) {
    id
  }
}
```

Passing a query without `skip` for `first` should use the default value