### PR TITLE
fix: fix missing default when args is not coming from gql schema

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -174,7 +174,7 @@ export function buildWhereQuery(fields, alias, where) {
 }
 
 export async function fetchSpaces(args) {
-  const { first, skip, where = {} } = args;
+  const { first = 20, skip = 0, where = {} } = args;
 
   const fields = { id: 'string', created: 'number' };
   const whereQuery = buildWhereQuery(fields, 's', where);


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Default value for `args` is missing for `fetchSpaces`, when called internally, and not via graphql.

## 💊 Fixes / Solution

Add back default args values for `first` and `skip` for `fetchSpaces`

## 🛠️ Tests

When applied with #785, the following query should now works:

```
query Space {
  space(id: "aave.eth") {
    id 
  }
}
```