### PR TITLE
fix: fix escape issue when address contains special characters

### DIFF
--- a/src/graphql/operations/roles.ts
+++ b/src/graphql/operations/roles.ts
@@ -10,14 +10,13 @@ export default async function (parent, args) {
 
   const query = `
     SELECT * FROM spaces
-    WHERE JSON_CONTAINS(LOWER(settings->'$.admins'), LOWER(?))
-      OR JSON_CONTAINS(LOWER(settings->'$.members'), LOWER(?))
-      OR JSON_CONTAINS(LOWER(settings->'$.moderators'), LOWER(?));
+    WHERE JSON_CONTAINS(LOWER(settings->'$.admins'), LOWER(JSON_QUOTE(?)))
+      OR JSON_CONTAINS(LOWER(settings->'$.members'), LOWER(JSON_QUOTE(?)))
+      OR JSON_CONTAINS(LOWER(settings->'$.moderators'), LOWER(JSON_QUOTE(?)));
   `;
-  const params: string[] = [`"${address}"`, `"${address}"`, `"${address}"`];
 
   try {
-    const data = await db.queryAsync(query, params);
+    const data = await db.queryAsync(query, [address, address, address]);
     return data.map((space: any) => {
       const settings = JSON.parse(space.settings);
       const permissions: string[] = [];


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The role graphql query is not escaping special characters properly, making the SQL query fail in some cases.

See invalid input in [SNAPSHOT-HUB-1Q](https://snapshot-labs.sentry.io/issues/4804737954/?referrer=github_integration)

## 💊 Fixes / Solution

Close #787 
Close [SNAPSHOT-HUB-1Q](https://snapshot-labs.sentry.io/issues/4804737954/?referrer=github_integration)

Escape the `address` input properly by using the SQL native `JSON_QUOTE` function, instead of basic string interpolation (`"${address}"`)

## 🚧 Changes

- Use `JSON_QUOTE` to escape input

## 🛠️ Tests

This query should work:

```
query { roles (where: {address: "0xd83261a97fc12d11853bfadae196b832f8aadf79"}) { permissions } }
```

Passing any incomplete address, such as `0x` should not return any result.