### PR TITLE
feat: add `turbo` filter to spaces

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -176,7 +176,7 @@ export function buildWhereQuery(fields, alias, where) {
 export async function fetchSpaces(args) {
   const { first = 20, skip = 0, where = {} } = args;
 
-  const fields = { id: 'string', created: 'number' };
+  const fields = { id: 'string', created: 'number', turbo: 'boolean' };
   const whereQuery = buildWhereQuery(fields, 's', where);
   const queryStr = whereQuery.query;
   const params: any[] = whereQuery.params;

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -113,6 +113,7 @@ input SpaceWhere {
   created_gte: Int
   created_lt: Int
   created_lte: Int
+  turbo: Boolean
 }
 
 input RankingWhere {


### PR DESCRIPTION
Add `turbo` filter to Space query, to retrieve only turbo spaces

Used by https://github.com/snapshot-labs/score-api/issues/1004