### PR TITLE
chore: allow node version > 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,5 @@
     "prettier": "^3.0.3",
     "start-server-and-test": "^2.0.0",
     "ts-jest": "^29.1.1"
-  },
-  "engines": {
-    "node": "^16.0.0"
   }
 }


### PR DESCRIPTION
This PR removes the `engines` property in package.json, to allow more node version.

This change will not affect the node version used on the prod server, which should remain on 16

This service have been tested, and should work on node 18