### PR TITLE
chore: normalize metrics path

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -40,7 +40,7 @@ export default function initMetrics(app: Express) {
     normalizedPath: [
       ['^/api/scores/.+', '/api/scores/#id'],
       ['^/api/spaces/([^/]+)(/poke)?$', '/api/spaces/#key$2'],
-      ['^/graphql/?$', '/graphql']
+      ['^/graphql.*$', '/graphql']
     ],
     whitelistedPath,
     errorHandler: (e: any) => capture(e)


### PR DESCRIPTION
Normalizing `graphql` path in metrics, so that `graphql/test/abc`, `graphql?test` etc... are considered as just `graphql`