### PR TITLE
feat: add endpoint to check for deleted spaces

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -42,14 +42,14 @@ router.get('/spaces/:key', async (req, res) => {
 
 router.post('/deleted-spaces', async (req, res) => {
   const { spaces } = req.body;
-  const id = (Array.isArray(spaces) ? spaces : [spaces])
+  const ids = (Array.isArray(spaces) ? spaces : [spaces])
     .map(i => i?.toString())
-    .filter(a => a);
+    .filter(i => i);
 
   try {
     return res.json(
-      id.length > 0
-        ? (await getDeletedSpaces(id)).map((s: { id: string }) => s.id)
+      ids.length > 0
+        ? (await getDeletedSpaces(ids)).map((s: { id: string }) => s.id)
         : []
     );
   } catch (e: any) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { getSpace } from './helpers/spaces';
+import { getSpace, getDeletedSpaces } from './helpers/spaces';
 import { name, version } from '../package.json';
 import { sendError } from './helpers/utils';
 
@@ -37,6 +37,24 @@ router.get('/spaces/:key', async (req, res) => {
       return sendError(res, 'server_error', 500);
     }
     return sendError(res, 'not_found', 404);
+  }
+});
+
+router.post('/deleted-spaces', async (req, res) => {
+  const { spaces } = req.body;
+  const id = (Array.isArray(spaces) ? spaces : [spaces])
+    .map(i => i?.toString())
+    .filter(a => a);
+
+  try {
+    return res.json(
+      id.length > 0
+        ? (await getDeletedSpaces(id)).map((s: { id: string }) => s.id)
+        : []
+    );
+  } catch (e: any) {
+    capture(e);
+    return sendError(res, 'server_error', 500);
   }
 });
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { getSpace, getDeletedSpaces } from './helpers/spaces';
+import { getSpace } from './helpers/spaces';
 import { name, version } from '../package.json';
 import { sendError } from './helpers/utils';
 
@@ -37,24 +37,6 @@ router.get('/spaces/:key', async (req, res) => {
       return sendError(res, 'server_error', 500);
     }
     return sendError(res, 'not_found', 404);
-  }
-});
-
-router.post('/deleted-spaces', async (req, res) => {
-  const { spaces } = req.body;
-  const ids = (Array.isArray(spaces) ? spaces : [spaces])
-    .map(i => i?.toString())
-    .filter(i => i);
-
-  try {
-    return res.json(
-      ids.length > 0
-        ? (await getDeletedSpaces(ids)).map((s: { id: string }) => s.id)
-        : []
-    );
-  } catch (e: any) {
-    capture(e);
-    return sendError(res, 'server_error', 500);
   }
 });
 

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -197,6 +197,16 @@ export async function getSpace(id: string) {
   };
 }
 
+export async function getDeletedSpaces(id: string[]) {
+  const query = `
+    SELECT id
+    FROM spaces
+    WHERE deleted = 1 AND id IN (?)
+    `;
+
+  return await db.queryAsync(query, [id]);
+}
+
 export default async function run() {
   try {
     await loadSpaces();

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -179,7 +179,7 @@ async function loadSpacesMetrics() {
 
 export async function getSpace(id: string) {
   const query = `
-    SELECT settings, flagged, verified, turbo, hibernated
+    SELECT settings, flagged, verified, turbo, hibernated, deleted
     FROM spaces
     WHERE id = ?
     LIMIT 1`;

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -197,14 +197,14 @@ export async function getSpace(id: string) {
   };
 }
 
-export async function getDeletedSpaces(id: string[]) {
+export async function getDeletedSpaces(ids: string[]) {
   const query = `
     SELECT id
     FROM spaces
     WHERE deleted = 1 AND id IN (?)
     `;
 
-  return await db.queryAsync(query, [id]);
+  return await db.queryAsync(query, [ids]);
 }
 
 export default async function run() {

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -181,7 +181,7 @@ export async function getSpace(id: string) {
   const query = `
     SELECT settings, flagged, verified, turbo, hibernated
     FROM spaces
-    WHERE deleted = 0 AND id = ?
+    WHERE id = ?
     LIMIT 1`;
 
   const [space] = await db.queryAsync(query, [id]);
@@ -193,18 +193,9 @@ export async function getSpace(id: string) {
     flagged: space.flagged === 1,
     verified: space.verified === 1,
     turbo: space.turbo === 1,
-    hibernated: space.hibernated === 1
+    hibernated: space.hibernated === 1,
+    deleted: space.deleted === 1
   };
-}
-
-export async function getDeletedSpaces(ids: string[]) {
-  const query = `
-    SELECT id
-    FROM spaces
-    WHERE deleted = 1 AND id IN (?)
-    `;
-
-  return await db.queryAsync(query, [ids]);
 }
 
 export default async function run() {

--- a/test/e2e/space.test.ts
+++ b/test/e2e/space.test.ts
@@ -67,19 +67,15 @@ describe('GET /api/space/:key', () => {
 
   describe('when the space is marked as deleted', () => {
     it('returns the space data with a deleted:true', async () => {
-      await db.queryAsync(
-        'UPDATE spaces SET deleted = 1 WHERE id = ?',
-        fixtures[0].id
-      );
-      const response = await fetch(`${HOST}/api/spaces/${fixtures[0].id}`);
+      const response = await fetch(`${HOST}/api/spaces/${fixtures[1].id}`);
 
-      const space = fixtures[0];
+      const space = fixtures[1];
       const expectedSpace = {
         flagged: space.flagged,
         verified: space.verified,
         turbo: space.turbo,
         hibernated: space.hibernated,
-        deleted: false,
+        deleted: true,
         ...space.settings
       };
 

--- a/test/e2e/space.test.ts
+++ b/test/e2e/space.test.ts
@@ -25,7 +25,7 @@ describe('GET /api/space/:key', () => {
   describe('when the space exists', () => {
     let response;
     beforeAll(async () => {
-      response = await fetch(`${HOST}/api/spaces/fabien.eth`);
+      response = await fetch(`${HOST}/api/spaces/${fixtures[0].id}`);
     });
 
     it('returns the correct HTTP response', () => {
@@ -42,6 +42,7 @@ describe('GET /api/space/:key', () => {
         verified: space.verified,
         turbo: space.turbo,
         hibernated: space.hibernated,
+        deleted: false,
         ...space.settings
       };
 
@@ -61,6 +62,28 @@ describe('GET /api/space/:key', () => {
         error: 'unauthorized',
         error_description: 'not_found'
       });
+    });
+  });
+
+  describe('when the space is marked as deleted', () => {
+    it('returns the space data with a deleted:true', async () => {
+      await db.queryAsync(
+        'UPDATE spaces SET deleted = 1 WHERE id = ?',
+        fixtures[0].id
+      );
+      const response = await fetch(`${HOST}/api/spaces/${fixtures[0].id}`);
+
+      const space = fixtures[0];
+      const expectedSpace = {
+        flagged: space.flagged,
+        verified: space.verified,
+        turbo: space.turbo,
+        hibernated: space.hibernated,
+        deleted: false,
+        ...space.settings
+      };
+
+      expect(response.json()).resolves.toEqual(expectedSpace);
     });
   });
 });

--- a/test/fixtures/spaces.ts
+++ b/test/fixtures/spaces.ts
@@ -9,6 +9,18 @@ const fixtures: Record<string, any>[] = [
     settings: { network: 1 },
     created: Math.floor(Date.now() / 1e3),
     updated: Math.floor(Date.now() / 1e3)
+  },
+  {
+    id: 'snap.eth',
+    name: 'snap.eth',
+    flagged: false,
+    verified: true,
+    turbo: false,
+    hibernated: false,
+    deleted: true,
+    settings: { network: 1 },
+    created: Math.floor(Date.now() / 1e3),
+    updated: Math.floor(Date.now() / 1e3)
   }
 ];
 


### PR DESCRIPTION
Fixes #796 and needed by https://github.com/snapshot-labs/snapshot/issues/4516

The GET /spaces/ID endpoint can now returns deleted spaces

Test with

```bash
curl http://localhost:3000/api/spaces/TEST-ID
```

Should return the space settings (if found), with a `deleted` property