### PR TITLE
fix: allow display of large number values

### DIFF
--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -402,8 +402,8 @@ type SpaceFilters {
 }
 
 type SpaceVoting {
-  delay: Int
-  period: Int
+  delay: Float
+  period: Float
   type: String
   quorum: Float
   blind: Boolean


### PR DESCRIPTION
Fixes #805

Fix error when voting period and delay are larger than MAX_INT

The same failing query should now return 

```json
{
  "data": {
    "spaces": [
      {
        "id": "richardfromkfc.eth",
        "name": "APPROVAL PROPOSAL",
        "voting": {
          "period": 864000000000000,
          "delay": 8640000000000000000
        }
      }
    ]
  }
}
```