### PR TITLE
chore: fix `test` command stuck waiting on wrong url

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "start": "node dist/src/index.js",
     "start:test": "dotenv -e test/.env.test yarn dev",
     "test:setup": "dotenv -e test/.env.test yarn ts-node ./test/setupDb.ts",
-    "test": "yarn test:setup; PORT=3030 start-server-and-test 'yarn start:test' 3030 'dotenv -e test/.env.test jest --runInBand'",
+    "test": "yarn test:setup; PORT=3030 start-server-and-test 'yarn start:test' http://localhost:3030 'dotenv -e test/.env.test jest --runInBand'",
     "test:unit": "dotenv -e test/.env.test jest test/unit/",
-    "test:e2e": "PORT=3030 start-server-and-test 'yarn start:test' 3030 'dotenv -e test/.env.test jest --runInBand --collectCoverage=false test/e2e/'"
+    "test:e2e": "PORT=3030 start-server-and-test 'yarn start:test' http://localhost:3030 'dotenv -e test/.env.test jest --runInBand --collectCoverage=false test/e2e/'"
   },
   "eslintConfig": {
     "extends": "@snapshot-labs"


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The `test` command may be stuck while using `start-server-and-test`, due to it listening on `127.0.0.1` instead of `localhost`. On some env, those 2 urls are the same, but not always (see https://www.npmjs.com/package/start-server-and-test#localhost-vs-0000-vs-127001)

## 💊 Fixes / Solution

`yarn dev` is starting on `localhost`, so `start-server-and-test` should also be explicitly told to listen on `localhost`

## 🚧 Changes

- Update `test` command to listen on the full url instead of just the port

## 🛠️ Tests

- Run `yarn test`
- It should run the test