### PR TITLE
fix: Include strategy networks and multichain networks in network count

### DIFF
--- a/src/graphql/operations/networks.ts
+++ b/src/graphql/operations/networks.ts
@@ -1,14 +1,29 @@
 import { spaces } from '../../helpers/spaces';
 
 export default function () {
-  const networks = {};
-  Object.values(spaces).forEach((space: any) => {
-    networks[space.network] = networks[space.network]
-      ? networks[space.network] + 1
-      : 1;
-  });
-  return Object.entries(networks).map(network => ({
-    id: network[0],
-    spacesCount: network[1]
+  const networks: any = Object.values(spaces).reduce((acc: any, space: any) => {
+    const spaceNetworks = [
+      space.network,
+      ...space.strategies.map((strategy: any) => strategy.network),
+      ...space.strategies.flatMap((strategy: any) =>
+        Array.isArray(strategy.params?.strategies)
+          ? strategy.params.strategies.map((param: any) => param.network)
+          : []
+      )
+    ];
+
+    // remove undefined and duplicates
+    const uniqueNetworks = [...new Set(spaceNetworks)].filter(Boolean);
+
+    uniqueNetworks.forEach(network => {
+      acc[network] = acc[network] ? acc[network] + 1 : 1;
+    });
+
+    return acc;
+  }, {});
+
+  return Object.entries(networks).map(([id, spacesCount]) => ({
+    id,
+    spacesCount
   }));
 }


### PR DESCRIPTION
Right now we are counting main space network, this change will add
- Strategy network count
- Networks used inside multichain strategy

Before change:
![image](https://github.com/snapshot-labs/snapshot-hub/assets/15967809/0ee7d4f8-4d5c-42ae-9494-5cebc2904c59)


After change: 
![image](https://github.com/snapshot-labs/snapshot-hub/assets/15967809/4b486eaf-b26d-4966-b13f-21b41140b32e)
