### PR TITLE
feat: Add boost fields to space query

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -83,6 +83,8 @@ export function formatSpace({
   space.voting.hideAbstain = space.voting.hideAbstain || false;
   space.voteValidation = space.voteValidation || { name: 'any', params: {} };
   space.delegationPortal = space.delegationPortal || null;
+  // disable boost by default until it's enabled
+  space.boost = space.boost || { disabled: true, bribeEnabled: false };
   space.strategies = space.strategies?.map(strategy => ({
     ...strategy,
     // By default return space network if strategy network is not defined

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -83,8 +83,7 @@ export function formatSpace({
   space.voting.hideAbstain = space.voting.hideAbstain || false;
   space.voteValidation = space.voteValidation || { name: 'any', params: {} };
   space.delegationPortal = space.delegationPortal || null;
-  // disable boost by default until it's enabled
-  space.boost = space.boost || { disabled: true, bribeEnabled: false };
+  space.boost = space.boost || { enabled: true, bribeEnabled: false };
   space.strategies = space.strategies?.map(strategy => ({
     ...strategy,
     // By default return space network if strategy network is not defined

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -383,6 +383,7 @@ type Space {
   hibernated: Boolean
   turbo: Boolean
   rank: Float
+  boost: BoostSettings
   created: Int!
 }
 
@@ -547,6 +548,11 @@ type Treasury {
   name: String
   address: String
   network: String
+}
+
+type BoostSettings {
+  disabled: Boolean
+  bribeEnabled: Boolean
 }
 
 type Vp {

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -551,7 +551,7 @@ type Treasury {
 }
 
 type BoostSettings {
-  disabled: Boolean
+  enabled: Boolean
   bribeEnabled: Boolean
 }
 


### PR DESCRIPTION
Fixes #822 

Add boost fields to space/spaces query so UI can retrieve them

### How to test:
- Try a query like 
```graphQL
{
  space(id:"thanku.eth") {
    id
    boost {
      enabled
      bribeEnabled
    }
  }
}
```
- It should return default values
- Now try changing the settings of your space directly on DB (or use UI https://github.com/snapshot-labs/snapshot/pull/4616 to update your DB settings) 
-  On you DB, try adding:
```JSON
"boost":{"enabled":true,"bribeEnabled":true}
```
- Now try the above query again, it should return updated values