### PR TITLE
Add Quorum type on proposal and space

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -77,6 +77,7 @@ export function formatSpace({
   space.voting.period = space.voting.period || null;
   space.voting.type = space.voting.type || null;
   space.voting.quorum = space.voting.quorum || null;
+  space.voting.quorumType = space.voting.quorumType || 'default';
   space.voting.blind = space.voting.blind || false;
   space.voting.privacy = space.voting.privacy || '';
   space.voting.aliased = space.voting.aliased || false;
@@ -319,6 +320,7 @@ export function formatProposal(proposal) {
     network: strategy.network || proposal.network
   }));
   proposal.privacy = proposal.privacy || '';
+  proposal.quorumType = proposal.quorum_type || 'default';
   return proposal;
 }
 

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -407,6 +407,7 @@ type SpaceVoting {
   period: Int
   type: String
   quorum: Float
+  quorumType: String
   blind: Boolean
   hideAbstain: Boolean
   privacy: String
@@ -433,6 +434,7 @@ type Proposal {
   start: Int!
   end: Int!
   quorum: Float!
+  quorumType: String!
   privacy: String
   snapshot: String
   state: String

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -407,7 +407,7 @@ type SpaceVoting {
   period: Int
   type: String
   quorum: Float
-  quorumType: String
+  quorumType: String!
   blind: Boolean
   hideAbstain: Boolean
   privacy: String

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -46,6 +46,7 @@ CREATE TABLE proposals (
   start INT(11) NOT NULL,
   end INT(11) NOT NULL,
   quorum DECIMAL(64,30) NOT NULL,
+  quorum_type VARCHAR(24) NOT NULL DEFAULT '',
   privacy VARCHAR(24) NOT NULL,
   snapshot INT(24) NOT NULL,
   app VARCHAR(24) NOT NULL,


### PR DESCRIPTION
Related https://github.com/snapshot-labs/snapshot/issues/4600

Returns `quorumType` on proposal and space

### How to test:
- Change `quorumType` in your space settings
- Create proposals with different `quorumType`
Try running a query like:
```
{
  spaces {
   id
    voting{
      quorumType
      quorum
    }
  }
}

{
  proposals {
    id
    quorum
    quorumType
  }
}
```
- Should return `default` by default and `optimistic` if changed

- [ ] On Hub DB run:
```SQL
ALTER TABLE proposals
ADD COLUMN quorum_type VARCHAR(24) DEFAULT '' AFTER quorum;
```