### PR TITLE
fix: Reduce wait time to two mins while loading spaces

### DIFF
--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -206,6 +206,6 @@ export default async function run() {
     capture(e);
     log.error(`[spaces] failed to load spaces, ${JSON.stringify(e)}`);
   }
-  await snapshot.utils.sleep(360e3);
+  await snapshot.utils.sleep(120e3);
   run();
 }


### PR DESCRIPTION
Reducing wait time to 2 mins from 6 mins, as 6 mins is quite high and it feels like something is down
