### PR TITLE
Fix: vote validation default value

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -292,10 +292,13 @@ export function formatProposal(proposal) {
   proposal.validation = jsonParse(proposal.validation, {
     name: 'any',
     params: {}
-  }) || {
-    name: 'any',
-    params: {}
-  };
+  });
+  if (!proposal.validation || Object.keys(proposal.validation).length === 0) {
+    proposal.validation = {
+      name: 'any',
+      params: {}
+    };
+  }
   proposal.plugins = jsonParse(proposal.plugins, {});
   proposal.scores = jsonParse(proposal.scores, []);
   proposal.scores_by_strategy = jsonParse(proposal.scores_by_strategy, []);


### PR DESCRIPTION
This one is a temporary fix for https://github.com/snapshot-labs/snapshot-sequencer/pull/325/files to return a default value when `validation` is `{}`

ideally, we will save 
```js
{
      name: 'any',
      params: {}
}
```
or `null` to this field 