### PR TITLE
feat: Add `strategy` and `plugin` filter on `spaces` and `ranking` queries

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -179,7 +179,7 @@ export async function fetchSpaces(args) {
 
   const fields = { id: 'string', created: 'number' };
   const whereQuery = buildWhereQuery(fields, 's', where);
-  const queryStr = whereQuery.query;
+  let queryStr = whereQuery.query;
   const params: any[] = whereQuery.params;
 
   let orderBy = args.orderBy || 'created';
@@ -187,6 +187,16 @@ export async function fetchSpaces(args) {
   if (!['created', 'updated', 'id'].includes(orderBy)) orderBy = 'created';
   orderDirection = orderDirection.toUpperCase();
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
+
+  if (where.strategy) {
+    queryStr += ` AND JSON_CONTAINS(JSON_EXTRACT(s.settings, '$.strategies[*].name'), JSON_ARRAY(?))`;
+    params.push(where.strategy);
+  }
+
+  if (where.plugin) {
+    queryStr += ` AND JSON_CONTAINS(JSON_KEYS(s.settings->'$.plugins'), JSON_ARRAY(?))`;
+    params.push(where.plugin);
+  }
 
   const query = `
     SELECT s.* FROM spaces s

--- a/src/graphql/operations/plugins.ts
+++ b/src/graphql/operations/plugins.ts
@@ -7,8 +7,8 @@ export default function () {
       plugins[plugin] = (plugins[plugin] || 0) + 1;
     });
   });
-  return Object.entries(plugins).map(network => ({
-    id: network[0],
-    spacesCount: network[1]
+  return Object.entries(plugins).map(plugin => ({
+    id: plugin[0],
+    spacesCount: plugin[1]
   }));
 }

--- a/src/graphql/operations/ranking.ts
+++ b/src/graphql/operations/ranking.ts
@@ -19,7 +19,13 @@ export default async function (_parent, args, context, info) {
       categories: {}
     };
 
-    const { search = '', category = '', network = '' } = where;
+    const {
+      search = '',
+      category = '',
+      network = '',
+      strategy = '',
+      plugin = ''
+    } = where;
     const searchStr = search.toLowerCase();
     let searchCategory = category.toLowerCase();
     if (searchCategory === 'all') searchCategory = '';
@@ -31,7 +37,18 @@ export default async function (_parent, args, context, info) {
       const filteredByNetwork = network
         ? space.networks.includes(network)
         : true;
-      if (filteredBySearch && filteredByNetwork) {
+      const filteredByStrategy = strategy
+        ? space.strategyNames.includes(strategy)
+        : true;
+      const filteredByPlugin = plugin
+        ? space.pluginNames.includes(plugin)
+        : true;
+      if (
+        filteredBySearch &&
+        filteredByNetwork &&
+        filteredByStrategy &&
+        filteredByPlugin
+      ) {
         // count categories, should not consider searchCategory for counting
         space.categories.forEach(category => {
           metrics.categories[category] =
@@ -43,7 +60,13 @@ export default async function (_parent, args, context, info) {
       const filteredByCategory = searchCategory
         ? space.categories.includes(searchCategory)
         : true;
-      return filteredBySearch && filteredByCategory && filteredByNetwork;
+      return (
+        filteredBySearch &&
+        filteredByCategory &&
+        filteredByNetwork &&
+        filteredByStrategy &&
+        filteredByPlugin
+      );
     });
 
     metrics.total = filteredSpaces.length;

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -113,6 +113,8 @@ input SpaceWhere {
   created_gte: Int
   created_lt: Int
   created_lte: Int
+  strategy: String
+  plugin: String
 }
 
 input RankingWhere {
@@ -121,6 +123,8 @@ input RankingWhere {
   search: String
   category: String
   network: String
+  strategy: String
+  plugin: String
 }
 
 input MessageWhere {

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -65,14 +65,15 @@ function mapSpaces() {
         .map(strategy => strategy?.network || space.network)
         .concat(space.network)
     );
-    const strategies = uniq(
-      space.strategies?.map(strategy => strategy.name) || []
+    const strategyNames = uniq(
+      (space.strategies || []).map(strategy => strategy.name) || []
     );
+    const pluginNames = uniq(Object.keys(space.plugins || {}) || []);
     const popularity = getPopularity(id, {
       verified,
       turbo,
       networks,
-      strategies
+      strategies: strategyNames
     });
 
     spacesMetadata[id] = {
@@ -94,7 +95,9 @@ function mapSpaces() {
         followersCount7d: spaceFollowers[id]?.count_7d || 0,
         votesCount: spaceVotes[id]?.count || 0,
         votesCount7d: spaceVotes[id]?.count_7d || 0
-      }
+      },
+      strategyNames,
+      pluginNames
     };
   });
 


### PR DESCRIPTION
## Summary

Right now there is no way to find spaces that use a particular strategy or plugin
For example, if someone wants to find spaces using Quorum plugin
This PR will add:
- `strategy` and `plugin` filters on `spaces` query
- `strategy` and `plugin` filter on `ranking` query (ranking query doesn't show private spaces)

### How to test:
- Try running the following queries

```GraphQL
{
  spaces (where:{strategy:"erc721-multi-registry"}) {
    id
    plugins
    strategies {
      name
      network
      params
    }
  }
}

```

```GraphQL
{
  spaces (where:{plugin:"domino"}) {
    id
    plugins
    strategies {
      name
      network
      params
    }
  }
}

```


```GraphQL
{
  ranking(where: {plugin: "domino"}) {
    metrics {
      total
    }
    items {
      id
      plugins
      verified
    }
  }
}

```


```GraphQL
{
  ranking(where: {strategy:"erc721-multi-registry"}) {
    metrics {
      total
    }
    items {
      id
      plugins
      verified
    }
  }
}

```