### PR TITLE
fix: fix error when variable is null

### DIFF
--- a/src/graphql/operations/ranking.ts
+++ b/src/graphql/operations/ranking.ts
@@ -26,8 +26,8 @@ export default async function (_parent, args, context, info) {
       strategy = '',
       plugin = ''
     } = where;
-    const searchStr = search.toLowerCase();
-    let searchCategory = category.toLowerCase();
+    const searchStr = search?.toLowerCase() || '';
+    let searchCategory = category?.toLowerCase() || '';
     if (searchCategory === 'all') searchCategory = '';
 
     let filteredSpaces = rankedSpaces.filter((space: any) => {


### PR DESCRIPTION
Fixes #841 .

Fix an error when variable is `null` instead of `string` type