### PR TITLE
feat: add `proposalsCount` and `votesCount` to users

### DIFF
--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -9,7 +9,8 @@ export default async function (parent, args) {
     SELECT
       u.*,
       SUM(l.vote_count) AS vote_count,
-      SUM(l.proposal_count) AS proposal_count
+      SUM(l.proposal_count) AS proposal_count,
+      MAX(l.last_vote) AS last_vote
     FROM users u
     JOIN leaderboard l ON BINARY l.user = BINARY u.id
     WHERE id = ?

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -5,7 +5,16 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 
 export default async function (parent, args) {
   const id = args.id;
-  const query = `SELECT u.* FROM users u WHERE id = ? LIMIT 1`;
+  const query = `
+    SELECT
+      u.*,
+      SUM(l.vote_count) AS vote_count,
+      SUM(l.proposal_count) AS proposal_count
+    FROM users u
+    JOIN leaderboard l ON BINARY l.user = BINARY u.id
+    WHERE id = ?
+    GROUP BY l.user
+    LIMIT 1`;
   try {
     const users = await db.queryAsync(query, id);
     if (users.length === 1) return formatUser(users[0]);

--- a/src/graphql/operations/users.ts
+++ b/src/graphql/operations/users.ts
@@ -8,36 +8,52 @@ export default async function (parent, args) {
 
   checkLimits(args, 'users');
 
-  const fields = {
-    id: 'string',
-    ipfs: 'string',
-    created: 'number'
-  };
+  const fields = { id: 'string', ipfs: 'string', created: 'number' };
+  const leaderboardFields = { vote_count: 'number', proposal_count: 'number' };
+
   const whereQuery = buildWhereQuery(fields, 'u', where);
-  const queryStr = whereQuery.query;
-  const params: any[] = whereQuery.params;
-
-  let orderBy = args.orderBy || 'created';
-  let orderDirection = args.orderDirection || 'desc';
-  if (!['created'].includes(orderBy)) orderBy = 'created';
-  orderBy = `u.${orderBy}`;
-  orderDirection = orderDirection.toUpperCase();
-  if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
-
-  let users: any[] = [];
+  const leaderboardWhereQuery = buildWhereQuery(leaderboardFields, 'l', where);
+  const queryStr = [whereQuery.query, leaderboardWhereQuery.query].join(' ');
+  const params = whereQuery.params.concat(
+    leaderboardWhereQuery.params,
+    skip,
+    first
+  );
 
   const query = `
-    SELECT u.* FROM users u
+    SELECT
+      u.*,
+      SUM(l.vote_count) AS vote_count,
+      SUM(l.proposal_count) AS proposal_count
+    FROM users u
+    JOIN leaderboard l ON BINARY l.user = BINARY u.id
     WHERE 1=1 ${queryStr}
-    ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?
+    GROUP BY u.id
+    ORDER BY ${getOrderBy(args.orderBy)} ${getOrderDirection(
+      args.orderDirection
+    )}
+    LIMIT ?, ?
   `;
-  params.push(skip, first);
   try {
-    users = await db.queryAsync(query, params);
-    return users.map(user => formatUser(user));
+    const users = await db.queryAsync(query, params);
+    return users.map(formatUser);
   } catch (e: any) {
     log.error(`[graphql] users, ${JSON.stringify(e)}`);
     capture(e, { args });
     return Promise.reject(new Error('request failed'));
   }
+}
+
+function getOrderDirection(direction: string | null) {
+  const orderDirection = (direction ?? 'desc').toUpperCase();
+
+  return ['ASC', 'DESC'].includes(orderDirection) ? orderDirection : 'DESC';
+}
+
+function getOrderBy(order: string | null | undefined) {
+  const orderBy = (order ?? 'created').toLowerCase();
+
+  return ['created', 'vote_count', 'proposal_count'].includes(orderBy)
+    ? orderBy
+    : 'created';
 }

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -316,6 +316,18 @@ input UsersWhere {
   created_gte: Int
   created_lt: Int
   created_lte: Int
+  vote_count: Int
+  vote_count_in: [Int]
+  vote_count_gt: Int
+  vote_count_gte: Int
+  vote_count_lt: Int
+  vote_count_lte: Int
+  proposal_count: Int
+  proposal_count_in: [Int]
+  proposal_count_gt: Int
+  proposal_count_gte: Int
+  proposal_count_lt: Int
+  proposal_count_lte: Int
 }
 
 input StatementsWhere {
@@ -521,6 +533,8 @@ type User {
   name: String
   about: String
   avatar: String
+  vote_count: Int
+  proposal_count: Int
   created: Int!
 }
 

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -535,6 +535,7 @@ type User {
   avatar: String
   vote_count: Int
   proposal_count: Int
+  last_vote: Int
   created: Int!
 }
 


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

We don't have a `proposal_count` and `vote_count` for the `User` object,

## 💊 Fixes / Solution

Add those missing properties, to be inline with the API from sx 

![Screenshot 2024-04-28 at 22 53 13](https://github.com/snapshot-labs/snapshot-hub/assets/495709/4d32dbac-0c75-4bf8-9733-c11bffd76eed)


## 🚧 Changes

- Return a `proposal_count` and `vote_count` properties for the User object (computed from the leaderboard table)
- Add filters to `users`, to filter them by proposals and votes count

## 🛠️ Tests

```graphql
{
  user(id: "0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3") {
   	id  
    proposal_count
    vote_count
  }
}

// Should return 

{
  "data": {
    "user": {
      "id": "0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3",
      "proposal_count": 9,
      "vote_count": 13
    }
  }
}
```

```graphql
{
  users(where: { proposal_count_gte: 10, vote_count_gte: 1 }) {
   	id  
    proposal_count
    vote_count
  }
}

// Should return 

{
  "data": {
    "users": [
      {
        "id": "0xd333Bc5c9670C9cEb18f9A2CF02C6E86807a8227",
        "proposal_count": 12,
        "vote_count": 5
      },
      {
        "id": "0xa561e70cd46B6445D98Ffa26e0288C9E49C70B1a",
        "proposal_count": 10,
        "vote_count": 8
      },
      {
        "id": "0x9f74662aD05840Ba35d111930501c617920dD68e",
        "proposal_count": 11,
        "vote_count": 7
      }
    ]
  }
}
```

## TODO 

- [ ] Waiting for #839 to be merged first