### PR TITLE
feat: add support for `network` field in follows

### DIFF
--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -280,6 +280,8 @@ input FollowWhere {
   follower_in: [String]
   space: String
   space_in: [String]
+  network: String
+  network_in: [String]
   created: Int
   created_in: [Int]
   created_gt: Int
@@ -504,6 +506,7 @@ type Follow {
   ipfs: String
   follower: String!
   space: Space!
+  network: String!
   created: Int!
 }
 

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -106,9 +106,12 @@ CREATE TABLE follows (
   ipfs VARCHAR(64) NOT NULL,
   follower VARCHAR(64) NOT NULL,
   space VARCHAR(64) NOT NULL,
+  network VARCHAR(24) NOT NULL DEFAULT 's',
   created INT(11) NOT NULL,
-  PRIMARY KEY (follower, space),
+  PRIMARY KEY (follower, space, network),
   INDEX ipfs (ipfs),
+  INDEX space (space),
+  INDEX network (network),
   INDEX created (created)
 );
 


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot-sequencer/issues/341

This PR add support for the new `network` field added to follows in https://github.com/snapshot-labs/snapshot-sequencer/pull/342

- Add `network` and `network_in` filter to follows
- Return the `network` field in follows

As we only have Space data for followed spaced of type `s`, all the spaces from other network will only return an `id`, with all other fields blank.

## Tests 

```graphql
{
  follows(where: {network: "s"}, first: 10) {
   id
    space {
      id 
      name
      about
      turbo
      flagged
      verified
    }
    network
  }
}
```