### PR TITLE
fix: Remove un-used id and id_in from RankingWhere

### DIFF
--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -118,8 +118,6 @@ input SpaceWhere {
 }
 
 input RankingWhere {
-  id: String
-  id_in: [String]
   search: String
   category: String
   network: String


### PR DESCRIPTION
These inputs were never handled in rankings query 