### PR TITLE
fix: return no spaces when controller is empty

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -180,7 +180,7 @@ export async function fetchSpaces(args) {
 
   const fields = { id: 'string', created: 'number' };
 
-  if (Object.hasOwnProperty.bind(where)('controller')) {
+  if ('controller' in where) {
     if (!where.controller) return [];
 
     where.id_in = await getControllerDomains(where.controller);

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -180,7 +180,9 @@ export async function fetchSpaces(args) {
 
   const fields = { id: 'string', created: 'number' };
 
-  if (where.controller) {
+  if (Object.hasOwnProperty.bind(where)('controller')) {
+    if (!where.controller) return [];
+
     where.id_in = await getControllerDomains(where.controller);
 
     delete where.controller;


### PR DESCRIPTION
Return an empty `spaces` result when the `controller` filter is empty

```graphql
query Spaces {
  spaces(
    first: 20,
    skip: 0,
    orderBy: "created",
    orderDirection: desc,
    where: { controller: "" }
  ) {
    id
  }
}
```

Should return 

```json
{
  "data": {
    "spaces": []
  }
}
```

and not all spaces.