### PR TITLE
fix: Allow lowercase voter address on votes query

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "prettier": "@snapshot-labs/prettier-config",
   "dependencies": {
+    "@ethersproject/address": "^5.7.0",
     "@graphql-tools/schema": "^10.0.0",
     "@snapshot-labs/keycard": "^0.5.1",
     "@snapshot-labs/snapshot-metrics": "^1.4.1",

--- a/src/graphql/operations/votes.ts
+++ b/src/graphql/operations/votes.ts
@@ -21,7 +21,7 @@ async function query(parent, args, context?, info?) {
     id: 'string',
     ipfs: 'string',
     space: 'string',
-    voter: 'string',
+    voter: 'EVMAddress',
     proposal: 'string',
     reason: 'string',
     app: 'string',


### PR DESCRIPTION
### Summary:
- Allow lowercase `voter` address on `votes` query
- Also allow inside `_not`, `_in`, `_not_in` cases 

### How to test:
- Try passing lowercase address in `voter` and `voter_in` 
```graphql
query Votes {
  votes(
    where: {voter: "0x24f15402c6bb870554489b2fd2049a85d75b982f"}
  ) {
    id
    voter
  }
}
```
- `voter_in: ["0x24f15402c6bb870554489b2fd2049a85d75b982f"]`
- `voter: "0x24F15402C6Bb870554489b2fd2049A85d75B982f"`
- `voter_in: ["0x24F15402C6Bb870554489b2fd2049A85d75B982f"]`
- Should return an error if someone passes invalid address `voter: "1234"`
