### PR TITLE
fix: Ignore if address is not a EVM address

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -27,6 +27,15 @@ const ARG_LIMITS = {
   }
 };
 
+export function formatAddress(address: string): string {
+  try {
+    return getAddress(address);
+  } catch (error) {
+    // return same address for now, but return error in the future, if address is not EVM or sn address
+    return address;
+  }
+}
+
 export function checkLimits(args: any = {}, type) {
   const { where = {} } = args;
   const typeLimits = { ...ARG_LIMITS.default, ...(ARG_LIMITS[type] || {}) };
@@ -127,8 +136,8 @@ export function buildWhereQuery(fields, alias, where) {
           const key = `${field}${condition}`;
           if (where[key]) {
             where[key] = condition.includes('in')
-              ? where[key].map(getAddress)
-              : getAddress(where[key]);
+              ? where[key].map(formatAddress)
+              : formatAddress(where[key]);
           }
         });
       } catch (e) {

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -1,16 +1,10 @@
 import db from '../../helpers/mysql';
-import { formatUser } from '../helpers';
+import { formatAddress, formatUser } from '../helpers';
 import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { getAddress } from '@ethersproject/address';
 
 export default async function (parent, args) {
-  let id = args.id;
-  try {
-    id = getAddress(id);
-  } catch (error) {
-    return Promise.reject(new Error('invalid id'));
-  }
+  const id = formatAddress(args.id);
   const query = `SELECT u.* FROM users u WHERE id = ? LIMIT 1`;
   try {
     const users = await db.queryAsync(query, id);


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/snapshot.js/pull/1032/

We don't have to return error if address is not a EVM address