### PR TITLE
fix: add support for starknet address

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@snapshot-labs/keycard": "^0.5.1",
     "@snapshot-labs/snapshot-metrics": "^1.4.1",
     "@snapshot-labs/snapshot-sentry": "^1.5.5",
-    "@snapshot-labs/snapshot.js": "^0.11.38",
+    "@snapshot-labs/snapshot.js": "0.12.0-beta.5",
     "bluebird": "^3.7.2",
     "connection-string": "^1.0.1",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "prettier": "@snapshot-labs/prettier-config",
   "dependencies": {
-    "@ethersproject/address": "^5.7.0",
     "@graphql-tools/schema": "^10.0.0",
     "@snapshot-labs/keycard": "^0.5.1",
     "@snapshot-labs/snapshot-metrics": "^1.4.1",

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -31,7 +31,15 @@ export function formatAddress(address: string): string {
   try {
     return getAddress(address);
   } catch (error) {
-    // return same address for now, but return error in the future, if address is not EVM or sn address
+    // Pad starknet address to 64 characters
+    if (/^0x[a-fA-F0-9]{43,64}$/.test(address)) {
+      const addr = address.split('0x').pop()!;
+      if (addr.length < 64) {
+        const padding = '0'.repeat(64 - addr.length);
+        return `0x${padding}${addr}`;
+      }
+    }
+
     return address;
   }
 }

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -27,6 +27,15 @@ const ARG_LIMITS = {
   }
 };
 
+export function formatAddress(address: string): string {
+  try {
+    return getAddress(address);
+  } catch (error) {
+    // return same address for now, but return error in the future, if address is not EVM or sn address
+    return address;
+  }
+}
+
 export function checkLimits(args: any = {}, type) {
   const { where = {} } = args;
   const typeLimits = { ...ARG_LIMITS.default, ...(ARG_LIMITS[type] || {}) };
@@ -127,8 +136,8 @@ export function buildWhereQuery(fields, alias, where) {
           const key = `${field}${condition}`;
           if (where[key]) {
             where[key] = condition.includes('in')
-              ? where[key].map(getAddress)
-              : getAddress(where[key]);
+              ? where[key].map(formatAddress)
+              : formatAddress(where[key]);
           }
         });
       } catch (e) {

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -120,7 +120,10 @@ export function formatSpace({
 
 export function formatAddresses(
   addresses: string[],
-  types: ('evmAddress' | 'starknetAddress')[]
+  types: ('evmAddress' | 'starknetAddress')[] = [
+    'evmAddress',
+    'starknetAddress'
+  ]
 ) {
   return addresses
     .map(address => {

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -115,20 +115,31 @@ export function formatSpace({
   return space;
 }
 
-export function buildWhereQuery(fields, alias, where) {
+export function buildWhereQuery(
+  fields: Record<string, string | string[]>,
+  alias: string,
+  where
+) {
   let query: any = '';
   const params: any[] = [];
 
   Object.entries(fields).forEach(([field, type]) => {
-    if (type === 'EVMAddress') {
+    const addressFormatter: string[] = [];
+    if (Array.from(type).includes('evmAddress')) addressFormatter.push('evm');
+    if (Array.from(type).includes('starknetAddress'))
+      addressFormatter.push('starknet');
+
+    if (addressFormatter.length > 0) {
       const conditions = ['', '_not', '_in', '_not_in'];
       try {
         conditions.forEach(condition => {
           const key = `${field}${condition}`;
           if (where[key]) {
             where[key] = condition.includes('in')
-              ? where[key].map(utils.getFormattedAddress)
-              : utils.getFormattedAddress(where[key]);
+              ? where[key].map(address =>
+                  utils.getFormattedAddress(address, addressFormatter)
+                )
+              : utils.getFormattedAddress(where[key], addressFormatter);
           }
         });
       } catch (e) {

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -143,6 +143,8 @@ export function formatAddresses(
       ) {
         return snapshot.utils.getFormattedAddress(address, 'starknet');
       }
+
+      throw new PublicError('Invalid address');
     })
     .filter(Boolean) as string[];
 }
@@ -166,16 +168,17 @@ export function buildWhereQuery(
 
         if (!where[key]) return;
 
-        const formattedAddresses = uniq(
-          formatAddresses(castArray(where[key]), arrayType)
-        );
+        try {
+          const formattedAddresses = uniq(
+            formatAddresses(castArray(where[key]), arrayType)
+          );
 
-        if (!formattedAddresses.length)
+          where[key] = Array.isArray(where[key])
+            ? formattedAddresses
+            : formattedAddresses[0];
+        } catch (e: any) {
           throw new PublicError(`Invalid addresses in ${field}`);
-
-        where[key] = Array.isArray(where[key])
-          ? formattedAddresses
-          : formattedAddresses[0];
+        }
       });
     }
     if (where[field] !== undefined && !Array.isArray(where[field])) {

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -1,8 +1,4 @@
-import {
-  getFormattedAddress,
-  isEvmAddress,
-  isStarknetAddress
-} from '@snapshot-labs/snapshot.js/src/utils';
+import snapshot from '@snapshot-labs/snapshot.js';
 import graphqlFields from 'graphql-fields';
 import fetch from 'node-fetch';
 import castArray from 'lodash/castArray';
@@ -130,13 +126,16 @@ export function formatAddresses(
     .map(address => {
       const results: string[] = [];
 
-      if (types.includes('evmAddress') && isEvmAddress(address)) {
-        results.push(getFormattedAddress(address, 'evm'));
+      if (
+        types.includes('evmAddress') &&
+        snapshot.utils.isEvmAddress(address)
+      ) {
+        results.push(snapshot.utils.getFormattedAddress(address, 'evm'));
       } else if (
         types.includes('starknetAddress') &&
-        isStarknetAddress(address)
+        snapshot.utils.isStarknetAddress(address)
       ) {
-        results.push(getFormattedAddress(address, 'starknet'));
+        results.push(snapshot.utils.getFormattedAddress(address, 'starknet'));
       }
 
       return results;

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -1,4 +1,4 @@
-import { getAddress } from '@ethersproject/address';
+import utils from '@snapshot-labs/snapshot.js/src/utils';
 import graphqlFields from 'graphql-fields';
 import fetch from 'node-fetch';
 import { jsonParse } from '../helpers/utils';
@@ -26,23 +26,6 @@ const ARG_LIMITS = {
     skip: 100000
   }
 };
-
-export function formatAddress(address: string): string {
-  try {
-    return getAddress(address);
-  } catch (error) {
-    // Pad starknet address to 64 characters
-    if (/^0x[a-fA-F0-9]{43,64}$/.test(address)) {
-      const addr = address.split('0x').pop()!;
-      if (addr.length < 64) {
-        const padding = '0'.repeat(64 - addr.length);
-        return `0x${padding}${addr}`;
-      }
-    }
-
-    return address;
-  }
-}
 
 export function checkLimits(args: any = {}, type) {
   const { where = {} } = args;
@@ -144,8 +127,8 @@ export function buildWhereQuery(fields, alias, where) {
           const key = `${field}${condition}`;
           if (where[key]) {
             where[key] = condition.includes('in')
-              ? where[key].map(formatAddress)
-              : formatAddress(where[key]);
+              ? where[key].map(utils.getFormattedAddress)
+              : utils.getFormattedAddress(where[key]);
           }
         });
       } catch (e) {

--- a/src/graphql/operations/aliases.ts
+++ b/src/graphql/operations/aliases.ts
@@ -11,8 +11,8 @@ export default async function (parent, args) {
   const fields = {
     id: 'string',
     ipfs: 'string',
-    address: 'EVMAddress',
-    alias: 'EVMAddress',
+    address: ['evmAddress', 'starknetAddress'],
+    alias: 'evmAddress',
     created: 'number'
   };
   const whereQuery = buildWhereQuery(fields, 'a', where);

--- a/src/graphql/operations/aliases.ts
+++ b/src/graphql/operations/aliases.ts
@@ -11,8 +11,8 @@ export default async function (parent, args) {
   const fields = {
     id: 'string',
     ipfs: 'string',
-    address: 'string',
-    alias: 'string',
+    address: 'EVMAddress',
+    alias: 'EVMAddress',
     created: 'number'
   };
   const whereQuery = buildWhereQuery(fields, 'a', where);

--- a/src/graphql/operations/follows.ts
+++ b/src/graphql/operations/follows.ts
@@ -11,7 +11,7 @@ export default async function (parent, args) {
   const fields = {
     id: 'string',
     ipfs: 'string',
-    follower: 'string',
+    follower: 'EVMAddress',
     space: 'string',
     network: 'string',
     created: 'number'

--- a/src/graphql/operations/follows.ts
+++ b/src/graphql/operations/follows.ts
@@ -11,7 +11,7 @@ export default async function (parent, args) {
   const fields = {
     id: 'string',
     ipfs: 'string',
-    follower: 'EVMAddress',
+    follower: ['evmAddress', 'starknetAddress'],
     space: 'string',
     network: 'string',
     created: 'number'

--- a/src/graphql/operations/leaderboards.ts
+++ b/src/graphql/operations/leaderboards.ts
@@ -9,7 +9,7 @@ export default async function (parent, args) {
   checkLimits(args, 'leaderboards');
 
   const fields = {
-    user: 'EVMAddress',
+    user: ['evmAddress', 'starknetAddress'],
     space: 'string',
     vote_count: 'number',
     proposal_count: 'number'

--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -12,7 +12,7 @@ export default async function (parent, args) {
     id: 'string',
     ipfs: 'string',
     space: 'string',
-    author: 'string',
+    author: 'EVMAddress',
     network: 'string',
     created: 'number',
     updated: 'number',

--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -12,7 +12,7 @@ export default async function (parent, args) {
     id: 'string',
     ipfs: 'string',
     space: 'string',
-    author: 'EVMAddress',
+    author: 'evmAddress',
     network: 'string',
     created: 'number',
     updated: 'number',

--- a/src/graphql/operations/statements.ts
+++ b/src/graphql/operations/statements.ts
@@ -13,7 +13,7 @@ export default async function (parent, args) {
     ipfs: 'string',
     space: 'string',
     created: 'number',
-    delegate: 'string'
+    delegate: 'EVMAddress'
   };
   const whereQuery = buildWhereQuery(fields, 's', where);
   const queryStr = whereQuery.query;

--- a/src/graphql/operations/statements.ts
+++ b/src/graphql/operations/statements.ts
@@ -13,7 +13,7 @@ export default async function (parent, args) {
     ipfs: 'string',
     space: 'string',
     created: 'number',
-    delegate: 'EVMAddress'
+    delegate: ['evmAddress', 'starknetAddress']
   };
   const whereQuery = buildWhereQuery(fields, 's', where);
   const queryStr = whereQuery.query;

--- a/src/graphql/operations/subscriptions.ts
+++ b/src/graphql/operations/subscriptions.ts
@@ -11,7 +11,7 @@ export default async function (parent, args) {
   const fields = {
     id: 'string',
     ipfs: 'string',
-    address: 'string',
+    address: 'EVMAddress',
     space: 'string',
     created: 'number'
   };

--- a/src/graphql/operations/subscriptions.ts
+++ b/src/graphql/operations/subscriptions.ts
@@ -11,7 +11,7 @@ export default async function (parent, args) {
   const fields = {
     id: 'string',
     ipfs: 'string',
-    address: 'EVMAddress',
+    address: 'evmAddress',
     space: 'string',
     created: 'number'
   };

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -4,10 +4,7 @@ import log from '../../helpers/log';
 import { formatUser, formatAddresses, PublicError } from '../helpers';
 
 export default async function (parent, args) {
-  const addresses = formatAddresses(
-    [args.id],
-    ['evmAddress', 'starknetAddress']
-  );
+  const addresses = formatAddresses([args.id]);
   if (!addresses.length) throw new PublicError('Invalid address');
 
   const query = `SELECT u.* FROM users u WHERE id = ? LIMIT 1`;

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -2,9 +2,15 @@ import db from '../../helpers/mysql';
 import { formatUser } from '../helpers';
 import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import { getAddress } from '@ethersproject/address';
 
 export default async function (parent, args) {
-  const id = args.id;
+  let id = args.id;
+  try {
+    id = getAddress(id);
+  } catch (error) {
+    return Promise.reject(new Error('invalid id'));
+  }
   const query = `SELECT u.* FROM users u WHERE id = ? LIMIT 1`;
   try {
     const users = await db.queryAsync(query, id);

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -1,10 +1,11 @@
-import db from '../../helpers/mysql';
-import { formatAddress, formatUser } from '../helpers';
-import log from '../../helpers/log';
+import utils from '@snapshot-labs/snapshot.js/src/utils';
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import db from '../../helpers/mysql';
+import { formatUser } from '../helpers';
+import log from '../../helpers/log';
 
 export default async function (parent, args) {
-  const id = formatAddress(args.id);
+  const id = utils.getFormattedAddress(args.id);
   const query = `SELECT u.* FROM users u WHERE id = ? LIMIT 1`;
   try {
     const users = await db.queryAsync(query, id);

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -1,14 +1,18 @@
-import utils from '@snapshot-labs/snapshot.js/src/utils';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import db from '../../helpers/mysql';
-import { formatUser } from '../helpers';
 import log from '../../helpers/log';
+import { formatUser, formatAddresses, PublicError } from '../helpers';
 
 export default async function (parent, args) {
-  const id = utils.getFormattedAddress(args.id);
+  const addresses = formatAddresses(
+    [args.id],
+    ['evmAddress', 'starknetAddress']
+  );
+  if (!addresses.length) throw new PublicError('Invalid address');
+
   const query = `SELECT u.* FROM users u WHERE id = ? LIMIT 1`;
   try {
-    const users = await db.queryAsync(query, id);
+    const users = await db.queryAsync(query, addresses[0]);
     if (users.length === 1) return formatUser(users[0]);
     return null;
   } catch (e: any) {

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -1,16 +1,10 @@
 import db from '../../helpers/mysql';
-import { formatUser } from '../helpers';
+import { formatAddress, formatUser } from '../helpers';
 import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { getAddress } from '@ethersproject/address';
 
 export default async function (parent, args) {
-  let id = args.id;
-  try {
-    id = getAddress(id);
-  } catch (error) {
-    return Promise.reject(new Error('invalid id'));
-  }
+  const id = formatAddress(args.id);
   const query = `SELECT u.* FROM users u WHERE id = ? LIMIT 1`;
   try {
     const users = await db.queryAsync(query, id);

--- a/src/graphql/operations/users.ts
+++ b/src/graphql/operations/users.ts
@@ -9,7 +9,7 @@ export default async function (parent, args) {
   checkLimits(args, 'users');
 
   const fields = {
-    id: 'EVMAddress',
+    id: ['evmAddress', 'starknetAddress'],
     ipfs: 'string',
     created: 'number'
   };

--- a/src/graphql/operations/users.ts
+++ b/src/graphql/operations/users.ts
@@ -9,7 +9,7 @@ export default async function (parent, args) {
   checkLimits(args, 'users');
 
   const fields = {
-    id: 'string',
+    id: 'EVMAddress',
     ipfs: 'string',
     created: 'number'
   };

--- a/src/graphql/operations/votes.ts
+++ b/src/graphql/operations/votes.ts
@@ -21,7 +21,7 @@ async function query(parent, args, context?, info?) {
     id: 'string',
     ipfs: 'string',
     space: 'string',
-    voter: 'EVMAddress',
+    voter: 'evmAddress',
     proposal: 'string',
     reason: 'string',
     app: 'string',

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -29,7 +29,7 @@ CREATE TABLE spaces (
 CREATE TABLE proposals (
   id VARCHAR(66) NOT NULL,
   ipfs VARCHAR(64) NOT NULL,
-  author VARCHAR(64) NOT NULL,
+  author VARCHAR(100) NOT NULL,
   created INT(11) NOT NULL,
   updated INT(11) DEFAULT NULL,
   space VARCHAR(64) NOT NULL,
@@ -76,9 +76,9 @@ CREATE TABLE proposals (
 CREATE TABLE votes (
   id VARCHAR(66) NOT NULL,
   ipfs VARCHAR(64) NOT NULL,
-  voter VARCHAR(64) NOT NULL,
+  voter VARCHAR(100) NOT NULL,
   created INT(11) NOT NULL,
-  space VARCHAR(64) NOT NULL,
+  space VARCHAR(100) NOT NULL,
   proposal VARCHAR(66) NOT NULL,
   choice JSON NOT NULL,
   metadata JSON NOT NULL,
@@ -104,7 +104,7 @@ CREATE TABLE votes (
 CREATE TABLE follows (
   id VARCHAR(66) NOT NULL,
   ipfs VARCHAR(64) NOT NULL,
-  follower VARCHAR(64) NOT NULL,
+  follower VARCHAR(100) NOT NULL,
   space VARCHAR(100) NOT NULL,
   network VARCHAR(24) NOT NULL DEFAULT 's',
   created INT(11) NOT NULL,
@@ -118,8 +118,8 @@ CREATE TABLE follows (
 CREATE TABLE aliases (
   id VARCHAR(66) NOT NULL,
   ipfs VARCHAR(64) NOT NULL,
-  address VARCHAR(64) NOT NULL,
-  alias VARCHAR(64) NOT NULL,
+  address VARCHAR(100) NOT NULL,
+  alias VARCHAR(100) NOT NULL,
   created INT(11) NOT NULL,
   PRIMARY KEY (address, alias),
   INDEX ipfs (ipfs)
@@ -128,7 +128,7 @@ CREATE TABLE aliases (
 CREATE TABLE subscriptions (
   id VARCHAR(66) NOT NULL,
   ipfs VARCHAR(64) NOT NULL,
-  address VARCHAR(64) NOT NULL,
+  address VARCHAR(100) NOT NULL,
   space VARCHAR(64) NOT NULL,
   created INT(11) NOT NULL,
   PRIMARY KEY (address, space),
@@ -137,7 +137,7 @@ CREATE TABLE subscriptions (
 );
 
 CREATE TABLE users (
-  id VARCHAR(64) NOT NULL,
+  id VARCHAR(100) NOT NULL,
   ipfs VARCHAR(64) NOT NULL,
   profile JSON,
   created INT(11) NOT NULL,
@@ -155,7 +155,7 @@ CREATE TABLE statements (
   statement TEXT,
   network VARCHAR(24) NOT NULL DEFAULT 's',
   discourse VARCHAR(64),
-  status VARCHAR(24) NOT NULL DEFAULT 'inactive',
+  status VARCHAR(24) NOT NULL DEFAULT 'INACTIVE',
   created INT(11) NOT NULL,
   updated INT(11) NOT NULL,
   PRIMARY KEY (delegate, space, network),
@@ -165,4 +165,17 @@ CREATE TABLE statements (
   INDEX created (created),
   INDEX updated (updated),
   INDEX status (status)
+);
+
+CREATE TABLE leaderboard (
+  user VARCHAR(100) NOT NULL,
+  space VARCHAR(64) NOT NULL,
+  vote_count SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  proposal_count SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  last_vote BIGINT,
+  PRIMARY KEY user_space (user,space),
+  INDEX space (space),
+  INDEX vote_count (vote_count),
+  INDEX proposal_count (proposal_count),
+  INDEX last_vote (last_vote)
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,6 +1119,18 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@noble/curves@~1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.3.0.tgz#01be46da4fd195822dab821e72f71bf4aeec635e"
+  integrity sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==
+  dependencies:
+    "@noble/hashes" "1.3.3"
+
+"@noble/hashes@1.3.3", "@noble/hashes@~1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
+  integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1193,6 +1205,49 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.0.5.tgz#a6d70ef7a0e71e083ea09b967df0a0ed742bc6ad"
   integrity sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==
+
+"@rometools/cli-darwin-arm64@12.1.3":
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-darwin-arm64/-/cli-darwin-arm64-12.1.3.tgz#b00fe225e34047c4dac63588e237b11ebec47694"
+  integrity sha512-AmFTUDYjBuEGQp/Wwps+2cqUr+qhR7gyXAUnkL5psCuNCz3807TrUq/ecOoct5MIavGJTH6R4aaSL6+f+VlBEg==
+
+"@rometools/cli-darwin-x64@12.1.3":
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-darwin-x64/-/cli-darwin-x64-12.1.3.tgz#e5bbf02afb1aab7447e743092245dea992b4b29f"
+  integrity sha512-k8MbWna8q4LRlb005N2X+JS1UQ+s3ZLBBvwk4fP8TBxlAJXUz17jLLu/Fi+7DTTEmMhM84TWj4FDKW+rNar28g==
+
+"@rometools/cli-linux-arm64@12.1.3":
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-linux-arm64/-/cli-linux-arm64-12.1.3.tgz#e75b01b74c134edc811e21fa7e1e440602930d59"
+  integrity sha512-X/uLhJ2/FNA3nu5TiyeNPqiD3OZoFfNfRvw6a3ut0jEREPvEn72NI7WPijH/gxSz55znfQ7UQ6iM4DZumUknJg==
+
+"@rometools/cli-linux-x64@12.1.3":
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-linux-x64/-/cli-linux-x64-12.1.3.tgz#2b9f4a68079783f275d4d27df83e4fa2220ec6fc"
+  integrity sha512-csP17q1eWiUXx9z6Jr/JJPibkplyKIwiWPYNzvPCGE8pHlKhwZj3YHRuu7Dm/4EOqx0XFIuqqWZUYm9bkIC8xg==
+
+"@rometools/cli-win32-arm64@12.1.3":
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-win32-arm64/-/cli-win32-arm64-12.1.3.tgz#714acb67ac4ea4c15e2bc6aea4dd290c76c8efc6"
+  integrity sha512-RymHWeod57EBOJY4P636CgUwYA6BQdkQjh56XKk4pLEHO6X1bFyMet2XL7KlHw5qOTalzuzf5jJqUs+vf3jdXQ==
+
+"@rometools/cli-win32-x64@12.1.3":
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/@rometools/cli-win32-x64/-/cli-win32-x64-12.1.3.tgz#b4f53491d2ca8f1234b3613b7cc73418ad8d76bb"
+  integrity sha512-yHSKYidqJMV9nADqg78GYA+cZ0hS1twANAjiFibQdXj9aGzD+s/IzIFEIi/U/OBLvWYg/SCw0QVozi2vTlKFDQ==
+
+"@scure/base@~1.1.3":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.7.tgz#fe973311a5c6267846aa131bc72e96c5d40d2b30"
+  integrity sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==
+
+"@scure/starknet@~1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@scure/starknet/-/starknet-1.0.0.tgz#4419bc2fdf70f3dd6cb461d36c878c9ef4419f8c"
+  integrity sha512-o5J57zY0f+2IL/mq8+AYJJ4Xpc1fOtDhr+mFQKbHnYFmm3WQrC+8zj2HEgxak1a+x86mhmBC1Kq305KUpVf0wg==
+  dependencies:
+    "@noble/curves" "~1.3.0"
+    "@noble/hashes" "~1.3.3"
 
 "@sentry-internal/tracing@7.81.1":
   version "7.81.1"
@@ -1316,10 +1371,10 @@
   dependencies:
     "@sentry/node" "^7.81.1"
 
-"@snapshot-labs/snapshot.js@^0.11.38":
-  version "0.11.38"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.11.38.tgz#bc7e35b6cf5df056ebdb474ef77e851a209b1bab"
-  integrity sha512-Pkiz+7uo5WAGKKJryT1ZyDY5we3QRVGLwQQGV6RDYLto1EmHGu1pEUX2AN/UUXnRzu7b+SPOynjBkAbJLZZq3A==
+"@snapshot-labs/snapshot.js@0.12.0-beta.5":
+  version "0.12.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.12.0-beta.5.tgz#93fc6f7136a495969e521c82ca8b480a90806193"
+  integrity sha512-07upweZIswU9xpMbTylapvVMFyoEDjty+MKOOn4a5s/xI0w99jmFI931Sci6kiTQSKR/YKtyIqHcHuVInVoYmw==
   dependencies:
     "@ensdomains/eth-ens-namehash" "^2.0.15"
     "@ethersproject/abi" "^5.6.4"
@@ -1336,6 +1391,7 @@
     cross-fetch "^3.1.6"
     json-to-graphql-query "^2.2.4"
     lodash.set "^4.3.2"
+    starknet "^5.24.3"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -1561,6 +1617,38 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+"abi-wan-kanabi-v1@npm:abi-wan-kanabi@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-1.0.3.tgz#0d8607f2a2ccb2151a69debea1c3bb68b76c5aa2"
+  integrity sha512-Xwva0AnhXx/IVlzo3/kwkI7Oa7ZX7codtcSn+Gmoa2PmjGPF/0jeVud9puasIPtB7V50+uBdUj4Mh3iATqtBvg==
+  dependencies:
+    abi-wan-kanabi "^1.0.1"
+    fs-extra "^10.0.0"
+    rome "^12.1.3"
+    typescript "^4.9.5"
+    yargs "^17.7.2"
+
+"abi-wan-kanabi-v2@npm:abi-wan-kanabi@^2.1.1":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-2.2.2.tgz#82c48e8fa08d9016cf92d3d81d494cc60e934693"
+  integrity sha512-sTCv2HyNIj1x2WFUoc9oL8ZT9liosrL+GoqEGZJK1kDND096CfA7lwx06vLxLWMocQ41FQXO3oliwoh/UZHYdQ==
+  dependencies:
+    ansicolors "^0.3.2"
+    cardinal "^2.1.1"
+    fs-extra "^10.0.0"
+    yargs "^17.7.2"
+
+abi-wan-kanabi@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-1.0.3.tgz#0d8607f2a2ccb2151a69debea1c3bb68b76c5aa2"
+  integrity sha512-Xwva0AnhXx/IVlzo3/kwkI7Oa7ZX7codtcSn+Gmoa2PmjGPF/0jeVud9puasIPtB7V50+uBdUj4Mh3iATqtBvg==
+  dependencies:
+    abi-wan-kanabi "^1.0.1"
+    fs-extra "^10.0.0"
+    rome "^12.1.3"
+    typescript "^4.9.5"
+    yargs "^17.7.2"
+
 accepts@^1.3.7, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -1663,6 +1751,11 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansicolors@^0.3.2, ansicolors@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz#665597de86a9ffe3aa9bfbe6cae5c6ea426b4979"
+  integrity sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==
 
 anymatch@^3.0.3:
   version "3.1.3"
@@ -2035,6 +2128,14 @@ caniuse-lite@^1.0.30001503:
   version "1.0.30001517"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz#90fabae294215c3495807eb24fc809e11dc2f0a8"
   integrity sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==
+
+cardinal@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cardinal/-/cardinal-2.1.1.tgz#7cc1055d822d212954d07b085dea251cc7bc5505"
+  integrity sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==
+  dependencies:
+    ansicolors "~0.3.2"
+    redeyed "~2.1.0"
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -2720,7 +2821,7 @@ espree@^9.4.0:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.3.0"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -3032,6 +3133,15 @@ from@~0:
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
   integrity sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==
 
+fs-extra@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -3205,7 +3315,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.2.9:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -3664,6 +3774,14 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
@@ -4156,6 +4274,15 @@ json5@^2.2.2, json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -4233,6 +4360,11 @@ logform@^2.3.2, logform@^2.4.0:
     ms "^2.1.1"
     safe-stable-stringify "^2.3.1"
     triple-beam "^1.3.0"
+
+lossless-json@^2.0.8:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/lossless-json/-/lossless-json-2.0.11.tgz#3137684c93fd99481c6f99c985efc9c9c5cc76a5"
+  integrity sha512-BP0vn+NGYvzDielvBZaFain/wgeJ1hTvURCqtKvhr1SCPePdaaTanmmcplrHfEJSJOUql7hk4FHwToNJjWRY3g==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -4413,7 +4545,7 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-node-fetch@2, node-fetch@^2.6.11, node-fetch@^2.7.0:
+node-fetch@2, node-fetch@^2.6.1, node-fetch@^2.6.11, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -4627,6 +4759,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+pako@^2.0.4:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -4894,6 +5031,13 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+redeyed@~2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-2.1.1.tgz#8984b5815d99cb220469c99eeeffe38913e6cc0b"
+  integrity sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==
+  dependencies:
+    esprima "~4.0.0"
+
 redis@^4.6.8:
   version "4.6.8"
   resolved "https://registry.yarnpkg.com/redis/-/redis-4.6.8.tgz#54c5992e8a5ba512506fe9f53142cadc405547e7"
@@ -4981,6 +5125,18 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rome@^12.1.3:
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/rome/-/rome-12.1.3.tgz#4d4d62cad16216843680bd3ca11a4c248134902a"
+  integrity sha512-e+ff72hxDpe/t5/Us7YRBVw3PBET7SeczTQNn6tvrWdrCaAw3qOukQQ+tDCkyFtS4yGsnhjrJbm43ctNbz27Yg==
+  optionalDependencies:
+    "@rometools/cli-darwin-arm64" "12.1.3"
+    "@rometools/cli-darwin-x64" "12.1.3"
+    "@rometools/cli-linux-arm64" "12.1.3"
+    "@rometools/cli-linux-x64" "12.1.3"
+    "@rometools/cli-win32-arm64" "12.1.3"
+    "@rometools/cli-win32-x64" "12.1.3"
 
 run-applescript@^5.0.0:
   version "5.0.0"
@@ -5218,6 +5374,21 @@ stack-utils@^2.0.3:
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+starknet@^5.24.3:
+  version "5.29.0"
+  resolved "https://registry.yarnpkg.com/starknet/-/starknet-5.29.0.tgz#26d8074340f26a2da4bc373169a1a5ed6dc9bedf"
+  integrity sha512-eEcd6uiYIwGvl8MtHOsXGBhREqjJk84M/qUkvPLQ3n/JAMkbKBGnygDlh+HAsvXJsGlMQfwrcVlm6KpDoPha7w==
+  dependencies:
+    "@noble/curves" "~1.3.0"
+    "@scure/base" "~1.1.3"
+    "@scure/starknet" "~1.0.0"
+    abi-wan-kanabi-v1 "npm:abi-wan-kanabi@^1.0.3"
+    abi-wan-kanabi-v2 "npm:abi-wan-kanabi@^2.1.1"
+    isomorphic-fetch "^3.0.0"
+    lossless-json "^2.0.8"
+    pako "^2.0.4"
+    url-join "^4.0.1"
 
 start-server-and-test@^2.0.0:
   version "2.0.0"
@@ -5604,6 +5775,11 @@ typescript@^4.7.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
@@ -5618,6 +5794,11 @@ undefsafe@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
+
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -5643,6 +5824,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
 url-value-parser@^2.0.0:
   version "2.2.0"
@@ -5705,6 +5891,11 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-fetch@^3.4.1:
+  version "3.6.20"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz#580ce6d791facec91d37c72890995a0b48d31c70"
+  integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -5855,7 +6046,7 @@ yargs@^16.1.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.3.1:
+yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/pitches/issues/83

This PR introduces some changes in order to accept starknet address as input (in `where` and `id` fields)

### Changes

- feat: add `starknetAddress` to `where` fields accepted values
- feat: allow passing an array to `where` values, so we can format using `evmAddress`, or `['evmAddress', 'starknetAddress']`
- refactor: rename `EVMAddress` to `evmAddress` in `where` fields formatter
- refactor: remove `@ethersproject/address` as dependency, will use the formatter exported by snapshot.js

### How to tests

- `yarn link` this branch of the SDK https://github.com/snapshot-labs/snapshot.js/pull/1032
- `yarn dev`
- you should be able to query fields by starknet address (e.g using a non padded starknet address or checksummed address, address will always be converted to padded/lowercased address before sent to mysql)
