### PR TITLE
fix: fix duplicates items on leaderboard pagination

### DIFF
--- a/src/graphql/operations/leaderboards.ts
+++ b/src/graphql/operations/leaderboards.ts
@@ -9,18 +9,21 @@ export default async function (parent, args) {
 
   checkLimits(args, 'leaderboards');
 
-  const ORDER_FIELDS = ['vote_count', 'proposal_count', 'user'];
+  const ORDER_FIELDS = ['vote_count', 'proposal_count', 'last_vote', 'user'];
   const DEFAULT_ORDER_FIELD = 'vote_count';
 
   const fields = {
     user: 'EVMAddress',
     space: 'string',
+    last_vote: 'number',
     vote_count: 'number',
     proposal_count: 'number'
   };
   const whereQuery = buildWhereQuery(fields, 'l', where);
 
-  const orderBy = ORDER_FIELDS.includes(args.orderBy)
+  const orderBy = uniq([...Object.keys(fields), ...ORDER_FIELDS]).includes(
+    args.orderBy
+  )
     ? args.orderBy
     : DEFAULT_ORDER_FIELD;
   let orderDirection = (args.orderDirection || 'desc').toUpperCase();


### PR DESCRIPTION
Will fix the offchain part for https://github.com/snapshot-labs/sx-monorepo/issues/480

## 🧿 Current issues / What's wrong ?

Paginating through the leaderboard is returning duplicates items.

## 💊 Fixes / Solution

Adding more ordering fields

## 🚧 Changes

- Always sort by 3 fields (`proposal_count`, `vote_count` and `user`), to avoid duplicates when multiple rows have the same counter
- The `orderBy` field will only move the given order field to the beginning

## 🛠️ Tests

```graphql
query {
  leaderboards(
    first: 20
    skip: 0
    orderBy: "proposal_count"
    orderDirection: desc
    where: {
    space: "safe.eth"
  }
  ) {
    user
    space
    proposalsCount
    votesCount
  }
}
```

Increment the `skip` by 20 will not returning duplicates items from previous page