### PR TITLE
fix: user query should return null if user does not exist

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -124,11 +124,20 @@ export function formatSpace({
   return space;
 }
 
-export function buildWhereQuery(fields, alias, where) {
+export function buildWhereQuery(
+  fields,
+  alias,
+  where,
+  options: { aliases?: Record<string, string> } = {}
+) {
   let query: any = '';
   const params: any[] = [];
 
   Object.entries(fields).forEach(([field, type]) => {
+    const aliasedFieldName = `${alias}.${
+      (options.aliases || {})[field] || field
+    }`;
+
     if (type === 'EVMAddress') {
       const conditions = ['', '_not', '_in', '_not_in'];
       try {
@@ -145,20 +154,20 @@ export function buildWhereQuery(fields, alias, where) {
       }
     }
     if (where[field] !== undefined) {
-      query += `AND ${alias}.${field} = ? `;
+      query += `AND ${aliasedFieldName} = ? `;
       params.push(where[field]);
     }
 
     const fieldNot = where[`${field}_not`];
     if (fieldNot !== undefined) {
-      query += `AND ${alias}.${field} != ? `;
+      query += `AND ${aliasedFieldName} != ? `;
       params.push(fieldNot);
     }
 
     const fieldIn = where[`${field}_in`];
     if (Array.isArray(fieldIn)) {
       if (fieldIn.length > 0) {
-        query += `AND ${alias}.${field} IN (?) `;
+        query += `AND ${aliasedFieldName} IN (?) `;
         params.push(fieldIn);
       } else {
         query += 'AND 1=0 ';
@@ -168,7 +177,7 @@ export function buildWhereQuery(fields, alias, where) {
     const fieldNotIn = where[`${field}_not_in`];
     if (Array.isArray(fieldNotIn)) {
       if (fieldNotIn.length > 0) {
-        query += `AND ${alias}.${field} NOT IN (?) `;
+        query += `AND ${aliasedFieldName} NOT IN (?) `;
         params.push(fieldNotIn);
       } else {
         query += 'AND 1=0 ';
@@ -181,19 +190,19 @@ export function buildWhereQuery(fields, alias, where) {
       const fieldLt = where[`${field}_lt`];
       const fieldLte = where[`${field}_lte`];
       if (fieldGt) {
-        query += `AND ${alias}.${field} > ? `;
+        query += `AND ${aliasedFieldName} > ? `;
         params.push(fieldGt);
       }
       if (fieldGte) {
-        query += `AND ${alias}.${field} >= ? `;
+        query += `AND ${aliasedFieldName} >= ? `;
         params.push(fieldGte);
       }
       if (fieldLt) {
-        query += `AND ${alias}.${field} < ? `;
+        query += `AND ${aliasedFieldName} < ? `;
         params.push(fieldLt);
       }
       if (fieldLte) {
-        query += `AND ${alias}.${field} <= ? `;
+        query += `AND ${aliasedFieldName} <= ? `;
         params.push(fieldLte);
       }
     }

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -326,12 +326,12 @@ export async function handleRelatedSpaces(info: any, spaces: any[]) {
 export function formatUser(user) {
   const profile = jsonParse(user.profile, {});
   delete user.profile;
+  user.id = user.userId || user.id;
   delete user.userId;
 
   return {
     ...user,
-    ...profile,
-    id: user.userId || user.id
+    ...profile
   };
 }
 

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -124,20 +124,11 @@ export function formatSpace({
   return space;
 }
 
-export function buildWhereQuery(
-  fields,
-  alias,
-  where,
-  options: { aliases?: Record<string, string> } = {}
-) {
+export function buildWhereQuery(fields, alias, where) {
   let query: any = '';
   const params: any[] = [];
 
   Object.entries(fields).forEach(([field, type]) => {
-    const aliasedFieldName = `${alias}.${
-      (options.aliases || {})[field] || field
-    }`;
-
     if (type === 'EVMAddress') {
       const conditions = ['', '_not', '_in', '_not_in'];
       try {
@@ -154,20 +145,20 @@ export function buildWhereQuery(
       }
     }
     if (where[field] !== undefined) {
-      query += `AND ${aliasedFieldName} = ? `;
+      query += `AND ${alias}.${field} = ? `;
       params.push(where[field]);
     }
 
     const fieldNot = where[`${field}_not`];
     if (fieldNot !== undefined) {
-      query += `AND ${aliasedFieldName} != ? `;
+      query += `AND ${alias}.${field} != ? `;
       params.push(fieldNot);
     }
 
     const fieldIn = where[`${field}_in`];
     if (Array.isArray(fieldIn)) {
       if (fieldIn.length > 0) {
-        query += `AND ${aliasedFieldName} IN (?) `;
+        query += `AND ${alias}.${field} IN (?) `;
         params.push(fieldIn);
       } else {
         query += 'AND 1=0 ';
@@ -177,7 +168,7 @@ export function buildWhereQuery(
     const fieldNotIn = where[`${field}_not_in`];
     if (Array.isArray(fieldNotIn)) {
       if (fieldNotIn.length > 0) {
-        query += `AND ${aliasedFieldName} NOT IN (?) `;
+        query += `AND ${alias}.${field} NOT IN (?) `;
         params.push(fieldNotIn);
       } else {
         query += 'AND 1=0 ';
@@ -190,19 +181,19 @@ export function buildWhereQuery(
       const fieldLt = where[`${field}_lt`];
       const fieldLte = where[`${field}_lte`];
       if (fieldGt) {
-        query += `AND ${aliasedFieldName} > ? `;
+        query += `AND ${alias}.${field} > ? `;
         params.push(fieldGt);
       }
       if (fieldGte) {
-        query += `AND ${aliasedFieldName} >= ? `;
+        query += `AND ${alias}.${field} >= ? `;
         params.push(fieldGte);
       }
       if (fieldLt) {
-        query += `AND ${aliasedFieldName} < ? `;
+        query += `AND ${alias}.${field} < ? `;
         params.push(fieldLt);
       }
       if (fieldLte) {
-        query += `AND ${aliasedFieldName} <= ? `;
+        query += `AND ${alias}.${field} <= ? `;
         params.push(fieldLte);
       }
     }

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -326,6 +326,8 @@ export async function handleRelatedSpaces(info: any, spaces: any[]) {
 export function formatUser(user) {
   const profile = jsonParse(user.profile, {});
   delete user.profile;
+  delete user.userId;
+
   return {
     ...user,
     ...profile,

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -328,7 +328,8 @@ export function formatUser(user) {
   delete user.profile;
   return {
     ...user,
-    ...profile
+    ...profile,
+    id: user.userId || user.id
   };
 }
 

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -363,8 +363,6 @@ export async function handleRelatedSpaces(info: any, spaces: any[]) {
 export function formatUser(user) {
   const profile = jsonParse(user.profile, {});
   delete user.profile;
-  user.id = user.userId || user.id;
-  delete user.userId;
 
   return {
     ...user,

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -6,19 +6,38 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 export default async function (parent, args) {
   const id = formatAddress(args.id);
   const query = `
-    SELECT
-      u.*,
-      SUM(l.vote_count) as votesCount,
-      SUM(l.proposal_count) as proposalsCount,
-      MAX(l.last_vote) as lastVote
-    FROM users u
-    LEFT JOIN leaderboard l ON l.user = u.id
-    WHERE id = ?
+    SELECT * FROM (
+      SELECT
+        u.*,
+        u.id as userId,
+        COALESCE(SUM(l.vote_count), 0) as votesCount,
+        COALESCE(SUM(l.proposal_count), 0) as proposalsCount,
+        MAX(l.last_vote) as lastVote
+      FROM users u
+      LEFT JOIN leaderboard l ON l.user = u.id
+      GROUP BY u.id
+      UNION
+      SELECT
+        u.*,
+        l.user as userId,
+        COALESCE(SUM(l.vote_count), 0) as votesCount,
+        COALESCE(SUM(l.proposal_count), 0) as proposalsCount,
+        MAX(l.last_vote) as lastVote
+      FROM users u
+      RIGHT JOIN leaderboard l ON l.user = u.id
+      GROUP BY l.user
+    ) AS t
+    WHERE t.userId = ?
     LIMIT 1`;
   try {
-    const users = await db.queryAsync(query, id);
-    if (users.length === 1) return formatUser(users[0]);
-    return null;
+    const users = await db.queryAsync(query, [id, id]);
+
+    if (!users.length) return null;
+
+    users[0].id = users[0].userId;
+    delete users[0].userId;
+
+    return formatUser(users[0]);
   } catch (e: any) {
     log.error(`[graphql] user, ${JSON.stringify(e)}`);
     capture(e, { args });

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -30,7 +30,7 @@ export default async function (parent, args) {
     WHERE t.userId = ?
     LIMIT 1`;
   try {
-    const users = await db.queryAsync(query, [id, id]);
+    const users = await db.queryAsync(query, id);
 
     if (!users.length) return null;
 

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -22,7 +22,7 @@ export default async function (parent, args) {
   try {
     const users = await db.queryAsync(query, addresses[0]);
 
-    if (!users.length) return null;
+    if (!users.length || !users[0].id) return null;
 
     return formatUser(users[0]);
   } catch (e: any) {

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -34,9 +34,6 @@ export default async function (parent, args) {
 
     if (!users.length) return null;
 
-    users[0].id = users[0].userId;
-    delete users[0].userId;
-
     return formatUser(users[0]);
   } catch (e: any) {
     log.error(`[graphql] user, ${JSON.stringify(e)}`);

--- a/src/graphql/operations/user.ts
+++ b/src/graphql/operations/user.ts
@@ -16,15 +16,14 @@ export default async function (parent, args) {
     FROM users u
     LEFT JOIN leaderboard l ON l.user = u.id
     WHERE u.id = ?
+    GROUP BY u.id
     LIMIT 1
   `;
 
   try {
     const users = await db.queryAsync(query, addresses[0]);
 
-    if (!users.length || !users[0].id) return null;
-
-    return formatUser(users[0]);
+    return users.length ? formatUser(users[0]) : null;
   } catch (e: any) {
     log.error(`[graphql] user, ${JSON.stringify(e)}`);
     capture(e, { args });

--- a/src/graphql/operations/users.ts
+++ b/src/graphql/operations/users.ts
@@ -3,6 +3,8 @@ import { buildWhereQuery, checkLimits, formatUser } from '../helpers';
 import log from '../../helpers/log';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 
+const TABLE_ALIAS = 't';
+
 export default async function (parent, args) {
   const { first, skip, where = {} } = args;
 
@@ -13,33 +15,48 @@ export default async function (parent, args) {
     ipfs: 'string',
     created: 'number'
   };
-  const whereQuery = buildWhereQuery(fields, 'u', where);
+  const whereQuery = buildWhereQuery(fields, TABLE_ALIAS, where, {
+    aliases: { id: 'userId' }
+  });
   const queryStr = whereQuery.query;
   const params: any[] = whereQuery.params;
 
   let orderBy = args.orderBy || 'created';
   let orderDirection = args.orderDirection || 'desc';
   if (!['created'].includes(orderBy)) orderBy = 'created';
-  orderBy = `u.${orderBy}`;
+  orderBy = `${TABLE_ALIAS}.${orderBy}`;
   orderDirection = orderDirection.toUpperCase();
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
 
   const query = `
-    SELECT
-      u.*,
-      SUM(l.vote_count) as votesCount,
-      SUM(l.proposal_count) as proposalsCount,
-      MAX(l.last_vote) as lastVote
-    FROM users u
-    INNER JOIN leaderboard l ON l.user = u.id
+  SELECT * FROM (
+      SELECT
+        u.*,
+        u.id as userId,
+        COALESCE(SUM(l.vote_count), 0) as votesCount,
+        COALESCE(SUM(l.proposal_count), 0) as proposalsCount,
+        MAX(l.last_vote) as lastVote
+      FROM users u
+      LEFT JOIN leaderboard l ON l.user = u.id
+      GROUP BY u.id
+      UNION
+      SELECT
+        u.*,
+        l.user as userId,
+        COALESCE(SUM(l.vote_count), 0) as votesCount,
+        COALESCE(SUM(l.proposal_count), 0) as proposalsCount,
+        MAX(l.last_vote) as lastVote
+      FROM users u
+      RIGHT JOIN leaderboard l ON l.user = u.id
+      GROUP BY l.user
+    ) AS ${TABLE_ALIAS}
     WHERE 1=1 ${queryStr}
-    GROUP BY u.id
     ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?
   `;
   params.push(skip, first);
   try {
     const users = await db.queryAsync(query, params);
-    return users.map(user => formatUser(user));
+    return users.map(formatUser);
   } catch (e: any) {
     log.error(`[graphql] users, ${JSON.stringify(e)}`);
     capture(e, { args });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Current code only return result when the address exist on user (and optionally on leaderboard with `LEFT JOIN`), so querying an user with an address not existing on the users table, but existing in the leaderboard table returns the following error

```graphql
query User {
  user(id: "0x00Cef6B61fd57d481e569C64Ac5280736023de7F") {
    id
  }
}
```

```graphql
{
  "errors": [
    {
      "message": "Cannot return null for non-nullable field User.id.",
      "locations": [
        {
          "line": 4,
          "column": 5
        }
      ],
      "path": [
        "user",
        "id"
      ]
    }
  ],
  "data": {
    "user": null
  }
}
```

This is due to the query always returning something, but without `users.id`, because of `COALESCE()` on the leaderboard counter columns.

## 💊 Fixes / Solution

Return `null` when user does not exist, instead of an user without ID

## 🚧 Changes

- When `JOIN` with leaderboard, return result only when the user exist on the `users` table

## 🛠️ Tests

Test with the following query, on a repo connected to the prod database (for the data)

```graphql
query User {
  user(id: "--ADDRESS--") {
    id
    name
    about
    avatar
    cover
    github
    twitter
    lens
    farcaster 
    proposalsCount
    votesCount
    lastVote
  }
}
```

with the following addresses:

- only on leaderboard: `0x0000000007c96AD6c9835204303c8fB35E48Ffc3`
- only on user: `0x2A7e46945277059D57a795CbecDb92DC29db69A6`
- on both tables: `0x04DB1bB49b7fFBcEC574f34D29c3153953890352`

It should gives similar results on a `users` query:

```graphql

query Users {
  users(where: { id_in: ["0x0000000007c96AD6c9835204303c8fB35E48Ffc3", "0x2A7e46945277059D57a795CbecDb92DC29db69A6", "0x04DB1bB49b7fFBcEC574f34D29c3153953890352", "0x04DB1bB49b7fFBcEC574f34D29c3153953890000"] }) {
    id
    name
    about
    avatar
    cover
    github
    twitter
    lens
    farcaster 
    proposalsCount
    votesCount
    lastVote
  }
}
```

The query should not return any results for `0x0000000007c96AD6c9835204303c8fB35E48Ffc3` (only leaderboard)