### PR TITLE
fix: Use lowercased proposal title to search

### DIFF
--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -41,8 +41,8 @@ export default async function (parent, args) {
 
   let searchSql = '';
   if (where.title_contains) {
-    searchSql = 'AND p.title LIKE ?';
-    params.push(`%${where.title_contains}%`);
+    searchSql = 'AND LOWER(p.title) LIKE ?';
+    params.push(`%${where.title_contains.toLowerCase()}%`);
   }
 
   if (where.strategies_contains) {


### PR DESCRIPTION
Fixes #892 

## Summary:
- Use lowercased titles to search with `LOWER`

How to test:
- Query using
```Graphql
query Proposals {
  proposals(
    where: {title_contains: "ARFC-ADDENDUM"}
  ) {
    id
    title
  }
}
```
- Should not work before but should work after