### PR TITLE
fix: ranking query should also return spaces with no popularity

### DIFF
--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -78,7 +78,7 @@ function sortSpaces() {
   });
 
   rankedSpaces = Object.values(spacesMetadata)
-    .filter(space => !space.private && !space.flagged && space.popularity > 0)
+    .filter(space => !space.private && !space.flagged)
     .sort((a, b) => b.popularity - a.popularity)
     .map((space, i) => {
       spacesMetadata[space.id].rank = i + 1;


### PR DESCRIPTION
### Summary
Some spaces don't have popularity when they are created, these should not be ignored by search
![image](https://github.com/user-attachments/assets/4e7de7cd-85d8-4919-8a2d-10f71881db8c)
![image](https://github.com/user-attachments/assets/a325ef61-eafb-4168-ae0f-d72f75da0dea)

### How to test 
- Try query before and after fix, it should return space 
```graphql
{
  ranking(where: {search: "ITP DAO"}) {
    items {
      id
    }
  }
}

```