### PR TITLE
feat: add support for new source column in statements table

### DIFF
--- a/src/graphql/operations/statements.ts
+++ b/src/graphql/operations/statements.ts
@@ -13,6 +13,7 @@ export default async function (parent, args) {
     ipfs: 'string',
     space: 'string',
     network: 'string',
+    source: 'string',
     created: 'number',
     delegate: ['evmAddress', 'starknetAddress']
   };

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -343,6 +343,8 @@ input StatementsWhere {
   created_gte: Int
   created_lt: Int
   created_lte: Int
+  source: String
+  source_in: [String]
 }
 
 input LeaderboardsWhere {
@@ -580,6 +582,7 @@ type Statement {
   statement: String
   discourse: String
   status: String
+  source: String
   created: Int!
   updated: Int!
 }

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -148,13 +148,14 @@ CREATE TABLE users (
 
 CREATE TABLE statements (
   id VARCHAR(66) NOT NULL,
-  ipfs VARCHAR(64) NOT NULL,
+  ipfs VARCHAR(64) DEFAULT NULL,
   delegate VARCHAR(100) NOT NULL,
   space VARCHAR(100) NOT NULL,
   about TEXT,
   statement TEXT,
   network VARCHAR(24) NOT NULL DEFAULT 's',
   discourse VARCHAR(64),
+  source VARCHAR(100) DEFAULT NULL,
   status VARCHAR(24) NOT NULL DEFAULT 'INACTIVE',
   created INT(11) NOT NULL,
   updated INT(11) NOT NULL,
@@ -164,6 +165,7 @@ CREATE TABLE statements (
   INDEX network (network),
   INDEX created (created),
   INDEX updated (updated),
+  INDEX source (source),
   INDEX status (status)
 );
 

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -155,7 +155,7 @@ CREATE TABLE statements (
   statement TEXT,
   network VARCHAR(24) NOT NULL DEFAULT 's',
   discourse VARCHAR(64),
-  source VARCHAR(100) DEFAULT NULL,
+  source VARCHAR(24) DEFAULT NULL,
   status VARCHAR(24) NOT NULL DEFAULT 'INACTIVE',
   created INT(11) NOT NULL,
   updated INT(11) NOT NULL,


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/167

Add support for the new `source` column in the statements table

- Add ability to query statements by source (string and array)
- Can return `source` in Statement
- Update schema.sql to reflect new source column

### Note 

To be merged after https://github.com/snapshot-labs/snapshot-sequencer/pull/422