### PR TITLE
feat: add `verified` field to SpacesWhere

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -234,6 +234,11 @@ export function buildWhereQuery(
         params.push(fieldLte);
       }
     }
+
+    if (type == 'boolean') {
+      query += `AND ${alias}.${field} = ? `;
+      params.push(where[field] ? '1' : '0');
+    }
   });
   return { query, params };
 }
@@ -241,7 +246,7 @@ export function buildWhereQuery(
 export async function fetchSpaces(args) {
   const { first = 20, skip = 0, where = {} } = args;
 
-  const fields = { id: 'string', created: 'number' };
+  const fields = { id: 'string', created: 'number', verified: 'boolean' };
 
   if ('controller' in where) {
     if (!where.controller) return [];

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -234,11 +234,6 @@ export function buildWhereQuery(
         params.push(fieldLte);
       }
     }
-
-    if (type === 'boolean') {
-      query += `AND ${alias}.${field} = ? `;
-      params.push(where[field] ? '1' : '0');
-    }
   });
   return { query, params };
 }

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -235,7 +235,7 @@ export function buildWhereQuery(
       }
     }
 
-    if (type == 'boolean') {
+    if (type === 'boolean') {
       query += `AND ${alias}.${field} = ? `;
       params.push(where[field] ? '1' : '0');
     }

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -124,6 +124,7 @@ input SpaceWhere {
   strategy: String
   plugin: String
   controller: String
+  verified: Boolean
 }
 
 input RankingWhere {


### PR DESCRIPTION
Closes #907

This PR add a `verified` filter to the spaces `where` argument

### Test 

```
query Spaces {
  spaces(where: { verified: true }) {
    id 
    name
  }
}
```

This should return a list of only verified spaces