### PR TITLE
feat: add network to delegation portal

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -94,7 +94,9 @@ export function formatSpace({
   space.voting.aliased = space.voting.aliased || false;
   space.voting.hideAbstain = space.voting.hideAbstain || false;
   space.voteValidation = space.voteValidation || { name: 'any', params: {} };
-  space.delegationPortal = space.delegationPortal || null;
+  space.delegationPortal = space.delegationPortal
+    ? { delegationNetwork: '1', ...space.delegationPortal }
+    : null;
   space.boost = space.boost || { enabled: true, bribeEnabled: false };
   space.strategies = space.strategies?.map(strategy => ({
     ...strategy,

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -505,6 +505,7 @@ type Validation {
 type DelegationPortal {
   delegationType: String!
   delegationContract: String!
+  delegationNetwork: String!
   delegationApi: String!
 }
 


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/177

This PR will return the new `delegationNetwork` property in the Delegation Portal setting.

When the property does not exist (for old data), it will always return `1` (ethereum).

### Test 

This space does not have `delegationNetwork` set, and the hub will return `1`

```graphql
query Spaces {
  spaces (where: { id: "test.wa0x6e.eth"}  ){
    id
    delegationPortal {
      delegationApi
      delegationType
      delegationNetwork
      delegationContract
    }
  }
}
```