### PR TITLE
feat: add support for space cover

### DIFF
--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -388,6 +388,7 @@ type Space {
   private: Boolean
   about: String
   avatar: String
+  cover: String
   terms: String
   location: String
   website: String


### PR DESCRIPTION
Working towards https://github.com/snapshot-labs/workflow/issues/152

This PR adds support for returning the `cover` field in the space settings when requested

See https://github.com/snapshot-labs/snapshot.js/pull/1055 for the corresponding write PR