### PR TITLE
fix: Exclude votes without proposals

### DIFF
--- a/src/graphql/operations/votes.ts
+++ b/src/graphql/operations/votes.ts
@@ -44,6 +44,7 @@ async function query(parent, args, context?, info?) {
 
   const query = `
     SELECT v.* FROM votes v
+    INNER JOIN proposals p ON v.proposal = p.id
     WHERE 1 = 1 ${queryStr}
     ORDER BY ${orderBy} ${orderDirection}, v.id ASC LIMIT ?, ?
   `;


### PR DESCRIPTION
Temporary fix for #760 

#### How to test:

- Test with:
```GraphQL
query Votes {
    votes(first: 1000, where: { voter: "0x24F15402C6Bb870554489b2fd2049A85d75B982f" }) {
     id  
    proposal {
        id
        space {
          id
        }
        ipfs
      }
    }
  }
  
 ```
 Should return values without `null` in proposal
- 
```GraphQL
query { 
  vote(id: "0xd954ffa9c8766c7f1195f867522ac759d8f752781d811941c91e289032e7df90") {
    
    id
    proposal {
      id
    }
  }
}
```
Should return `null`
 
 