### PR TITLE
fix: Add proposalCount1d on spaces

### DIFF
--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -414,6 +414,7 @@ type Space {
   treasuries: [Treasury]
   activeProposals: Int
   proposalsCount: Int
+  proposalsCount1d: Int
   proposalsCount7d: Int
   followersCount: Int
   followersCount7d: Int


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/workflow/issues/134

### Summary:
- Adds a new property proposalCount1d on spaces query
- Note that these counts gets updated every 2 mins ([approved](https://discord.com/channels/955773041898573854/1285170554395164704/1285174119079608374))


### How to test:
```graphql
{
 spaces(where:{id:"thanku.eth"}){
    proposalsCount1d
    proposalsCount7d
    name
  }
}
```