### PR TITLE
fix: fix issue where sub spaces querying return 20 results max

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -348,6 +348,7 @@ async function fetchRelatedSpaces(spaces) {
   }, []);
 
   return fetchSpaces({
+    first: relatedSpaceIDs.length,
     where: { id_in: relatedSpaceIDs }
   });
 }


### PR DESCRIPTION
Fix an issue where querying multiple spaces, with a combined total of subspaces > 20, is returning 20 subspaces max
