### PR TITLE
feat: Add labels to space queries

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -111,6 +111,7 @@ export function formatSpace({
   }
   space.validation = space.validation || { name: 'any', params: {} };
   space.treasuries = space.treasuries || [];
+  space.labels = space.labels || [];
 
   space.verified = verified ?? null;
   space.flagged = flagged ?? null;

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -413,6 +413,7 @@ type Space {
   voteValidation: Validation
   delegationPortal: DelegationPortal
   treasuries: [Treasury]
+  labels: [Label]
   activeProposals: Int
   proposalsCount: Int
   proposalsCount1d: Int
@@ -612,6 +613,13 @@ type Treasury {
   name: String
   address: String
   network: String
+}
+
+type Label {
+  id: String
+  name: String
+  description: String
+  color: String
 }
 
 type BoostSettings {


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/workflow/issues/143

### Summary
- Add `labels` to `spaces` query

### How to test
- Add following to your space settings
```JSON
"labels": [
    {
      "id": "96ac1059",
      "name": "Test 2",
      "color": "#52AA53",
      "description": "Description 2"
    },
    {
      "id": "810fb747",
      "name": "Test",
      "color": "#8C5065",
      "description": "Test desc."
    }
  ],
```
- Query with your space
```GraphQL
{
 spaces(where:{id:"thanku.eth"}){
  labels {
    id
    name
    description
    color
  }
  }
}
```