### PR TITLE
fix: return snapshot as number

### DIFF
--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -485,7 +485,7 @@ type Proposal {
   quorum: Float!
   quorumType: String!
   privacy: String
-  snapshot: String
+  snapshot: Int
   state: String
   link: String
   app: String


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/232

This PR returns the `snapshot` property as number (since in the table, it's an INT column, and on the front end, we're expecting a number)