### PR TITLE
feat: labels on proposal and proposals queries

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -380,6 +380,7 @@ export function formatUser(user) {
 
 export function formatProposal(proposal) {
   proposal.choices = jsonParse(proposal.choices, []);
+  proposal.labels = jsonParse(proposal.labels, []) || [];
   proposal.strategies = jsonParse(proposal.strategies, []);
   proposal.validation = jsonParse(proposal.validation, {
     name: 'any',

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -480,6 +480,7 @@ type Proposal {
   body: String
   discussion: String!
   choices: [String]!
+  labels: [String]!
   start: Int!
   end: Int!
   quorum: Float!

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE proposals (
   body MEDIUMTEXT NOT NULL,
   discussion TEXT NOT NULL,
   choices JSON NOT NULL,
+  labels JSON DEFAULT NULL,
   start INT(11) NOT NULL,
   end INT(11) NOT NULL,
   quorum DECIMAL(64,30) NOT NULL,


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/workflow/issues/143

### Summary
- Accepts labels on proposals

### How to test
- Create proposals with labels using https://github.com/snapshot-labs/snapshot-sequencer/pull/449
- Or add following into labels coloumn
```
[
  "e72db302",
  "96ac1059"
]
```
- Run a query like
```graphql
{
  proposals{
    labels
  }
}
```