### PR TITLE
feat: add new options endpoint

### DIFF
--- a/src/graphql/operations/index.ts
+++ b/src/graphql/operations/index.ts
@@ -3,6 +3,7 @@ import follows from './follows';
 import leaderboards from './leaderboards';
 import messages from './messages';
 import networks from './networks';
+import options from './options';
 import plugins from './plugins';
 import proposal from './proposal';
 import proposals from './proposals';
@@ -36,6 +37,7 @@ export default {
   subscriptions,
   skins,
   networks,
+  options,
   validations,
   plugins,
   strategies,

--- a/src/graphql/operations/options.ts
+++ b/src/graphql/operations/options.ts
@@ -1,5 +1,5 @@
-import snapshot from '@snapshot-labs/snapshot.js';
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import snapshot from '@snapshot-labs/snapshot.js';
 import log from '../../helpers/log';
 import db from '../../helpers/mysql';
 

--- a/src/graphql/operations/options.ts
+++ b/src/graphql/operations/options.ts
@@ -1,0 +1,13 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import log from '../../helpers/log';
+import db from '../../helpers/mysql';
+
+export default async function (_, args) {
+  try {
+    return await db.queryAsync('SELECT s.* FROM options s');
+  } catch (e: any) {
+    log.error(`[graphql] options, ${JSON.stringify(e)}`);
+    capture(e, { args });
+    return Promise.reject(new Error('request failed'));
+  }
+}

--- a/src/graphql/operations/options.ts
+++ b/src/graphql/operations/options.ts
@@ -3,7 +3,7 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import log from '../../helpers/log';
 import db from '../../helpers/mysql';
 
-const RUN_INTERVAL = 12e3;
+const RUN_INTERVAL = 120e3;
 
 let options = [];
 

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -110,6 +110,8 @@ type Query {
     orderBy: String
     orderDirection: OrderDirection
   ): [Leaderboard]
+
+  options: [Option]
 }
 
 input SpaceWhere {
@@ -639,4 +641,9 @@ type Leaderboard {
   proposalsCount: Int
   votesCount: Int
   lastVote: Int
+}
+
+type Option {
+  name: String
+  value: String
 }

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -183,3 +183,9 @@ CREATE TABLE leaderboard (
   INDEX proposal_count (proposal_count),
   INDEX last_vote (last_vote)
 );
+
+CREATE TABLE options (
+  name VARCHAR(100) NOT NULL,
+  value VARCHAR(100) NOT NULL,
+  PRIMARY KEY (name)
+);


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/223

This PR adds a new `options` endpoint to return all data from the `options` table

Endpoint do not have any filter and pagination, and will always return all results.

Create the table with

```sql
CREATE TABLE options (
  name VARCHAR(100) NOT NULL,
  value VARCHAR(100) NOT NULL,
  PRIMARY KEY (name)
);
```

Then you can query with 

```graphql
query {
  options {
  	name 
  	value
	}
}
```

which should return something like 

```
{
  "data": {
    "options": [
      {
        "name": "limit.test",
        "value": "12"
      }
    ]
  }
}
```

Insert data for mainnet (from https://github.com/snapshot-labs/snapshot-sequencer/blob/2a94d8fdcb592d9b087a33508eb02db76613cccd/src/helpers/limits.ts)

```sql
INSERT INTO `options` (`name`, `value`) VALUES
('ecosystem_spaces', 'orbapp.eth,cakevote.eth,outcome.eth,polls.lenster.xyz,daotest.dcl.eth,arbitrumfoundation.eth'),
('limit.active_proposals_per_author', '20'),
('limit.ecosystem_space.proposal.day', '150'),
('limit.ecosystem_space.proposal.month', '750'),
('limit.flagged_space.proposal.day', '0'),
('limit.flagged_space.proposal.month', '0'),
('limit.follows_per_user', '25'),
('limit.space.proposal.day', '3'),
('limit.space.proposal.month', '15'),
('limit.turbo_space.proposal.day', '40'),
('limit.turbo_space.proposal.month', '200'),
('limit.verified_space.proposal.day', '20'),
('limit.verified_space.proposal.month', '100');
```

Should be the same for testnet, beside ecosystem spaces, which should just be `citiesdao.eth`