### PR TITLE
fix: Use domain field instead of one in JSON

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -63,6 +63,7 @@ export function checkLimits(args: any = {}, type) {
 export function formatSpace({
   id,
   settings,
+  domain,
   verified,
   turbo,
   flagged,
@@ -72,6 +73,7 @@ export function formatSpace({
   const space = { ...jsonParse(settings, {}), ...spaceMetadata.counts };
 
   space.id = id;
+  space.domain = domain || '';
   space.private = space.private || false;
   space.avatar = space.avatar || '';
   space.about = space.about || '';
@@ -403,6 +405,7 @@ export function formatProposal(proposal) {
   proposal.space = formatSpace({
     id: proposal.space,
     settings: proposal.settings,
+    domain: proposal.spaceDomain,
     verified: proposal.spaceVerified,
     turbo: proposal.spaceTurbo,
     flagged: proposal.spaceFlagged,
@@ -426,6 +429,7 @@ export function formatVote(vote) {
   vote.vp_by_strategy = jsonParse(vote.vp_by_strategy, []);
   vote.space = formatSpace({
     id: vote.space,
+    domain: vote.spaceDomain,
     settings: vote.settings,
     verified: vote.spaceVerified,
     turbo: vote.spaceTurbo,
@@ -439,6 +443,7 @@ export function formatFollow(follow) {
   follow.space = formatSpace({
     id: follow.space,
     settings: follow.settings,
+    domain: follow.spaceDomain,
     verified: follow.spaceVerified,
     turbo: follow.spaceTurbo,
     flagged: follow.spaceFlagged,
@@ -451,6 +456,7 @@ export function formatSubscription(subscription) {
   subscription.space = formatSpace({
     id: subscription.space,
     settings: subscription.settings,
+    domain: subscription.spaceDomain,
     verified: subscription.spaceVerified,
     turbo: subscription.spaceTurbo,
     flagged: subscription.spaceFlagged,

--- a/src/graphql/operations/follows.ts
+++ b/src/graphql/operations/follows.ts
@@ -30,6 +30,7 @@ export default async function (parent, args) {
   const query = `
     SELECT f.*,
       spaces.settings,
+      spaces.domain as spaceDomain,
       spaces.flagged as spaceFlagged,
       spaces.verified as spaceVerified,
       spaces.turbo as spaceTurbo,

--- a/src/graphql/operations/proposal.ts
+++ b/src/graphql/operations/proposal.ts
@@ -7,6 +7,7 @@ export default async function (parent, { id }) {
   const query = `
     SELECT p.*,
       spaces.settings,
+      spaces.domain as spaceDomain,
       spaces.flagged as spaceFlagged,
       spaces.verified as spaceVerified,
       spaces.turbo as spaceTurbo,

--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -82,6 +82,7 @@ export default async function (parent, args) {
   const query = `
     SELECT p.*,
       spaces.settings,
+      spaces.domain as spaceDomain,
       spaces.flagged as spaceFlagged,
       spaces.verified as spaceVerified,
       spaces.turbo as spaceTurbo,

--- a/src/graphql/operations/subscriptions.ts
+++ b/src/graphql/operations/subscriptions.ts
@@ -31,6 +31,7 @@ export default async function (parent, args) {
   const query = `
     SELECT s.*,
       spaces.settings,
+      spaces.domain as spaceDomain,
       spaces.flagged as spaceFlagged,
       spaces.verified as spaceVerified,
       spaces.turbo as spaceTurbo,

--- a/src/graphql/operations/votes.ts
+++ b/src/graphql/operations/votes.ts
@@ -90,6 +90,7 @@ async function query(parent, args, context?, info?) {
     const query = `
       SELECT p.*,
         spaces.settings,
+        spaces.domain as spaceDomain,
         spaces.flagged as spaceFlagged,
         spaces.verified as spaceVerified,
         spaces.turbo as spaceTurbo,

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -268,7 +268,7 @@ async function loadSpacesMetrics() {
 
 export async function getSpace(id: string) {
   const query = `
-    SELECT settings, flagged, verified, turbo, hibernated, deleted, follower_count, proposal_count, vote_count
+    SELECT settings, domain, flagged, verified, turbo, hibernated, deleted, follower_count, proposal_count, vote_count
     FROM spaces
     WHERE id = ?
     LIMIT 1`;
@@ -279,6 +279,7 @@ export async function getSpace(id: string) {
 
   return {
     ...JSON.parse(space.settings),
+    domain: space.domain,
     flagged: space.flagged === 1,
     verified: space.verified === 1,
     turbo: space.turbo === 1,

--- a/test/e2e/space.test.ts
+++ b/test/e2e/space.test.ts
@@ -43,6 +43,7 @@ describe('GET /api/space/:key', () => {
         turbo: space.turbo,
         hibernated: space.hibernated,
         deleted: false,
+        domain: space.domain,
         ...space.settings
       };
 
@@ -76,6 +77,7 @@ describe('GET /api/space/:key', () => {
         turbo: space.turbo,
         hibernated: space.hibernated,
         deleted: true,
+        domain: space.domain,
         ...space.settings
       };
 

--- a/test/fixtures/spaces.ts
+++ b/test/fixtures/spaces.ts
@@ -1,3 +1,5 @@
+import { domain } from "process";
+
 const fixtures: Record<string, any>[] = [
   {
     id: 'fabien.eth',
@@ -6,6 +8,7 @@ const fixtures: Record<string, any>[] = [
     verified: true,
     turbo: false,
     hibernated: false,
+    domain: 'test.com',
     settings: { network: 1 },
     created: Math.floor(Date.now() / 1e3),
     updated: Math.floor(Date.now() / 1e3)
@@ -18,6 +21,7 @@ const fixtures: Record<string, any>[] = [
     turbo: false,
     hibernated: false,
     deleted: true,
+    domain: 'test1.com',
     settings: { network: 1 },
     created: Math.floor(Date.now() / 1e3),
     updated: Math.floor(Date.now() / 1e3)

--- a/test/fixtures/spaces.ts
+++ b/test/fixtures/spaces.ts
@@ -1,5 +1,3 @@
-import { domain } from "process";
-
 const fixtures: Record<string, any>[] = [
   {
     id: 'fabien.eth',


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/workflow/issues/241

### Summery
- Use `domain` field instead of `domain` in settings JSON

### How to test:
- Change `domain` field and `settings.domain`
- Hub queries should return `domain` field instead of domain in JSON