### PR TITLE
feat: add filter to search proposals by labels

### DIFF
--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -72,7 +72,7 @@ export default async function (parent, args) {
     searchSql += ' AND p.flagged = 0';
   }
 
-  if (where.labels_in) {
+  if (where?.labels_in?.length) {
     searchSql += ' AND JSON_OVERLAPS(p.labels, ?)';
     params.push(JSON.stringify(where.labels_in));
   }

--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -72,6 +72,11 @@ export default async function (parent, args) {
     searchSql += ' AND p.flagged = 0';
   }
 
+  if (where.labels_in) {
+    searchSql += ' AND JSON_OVERLAPS(p.labels, ?)';
+    params.push(JSON.stringify(where.labels_in));
+  }
+
   let orderBy = args.orderBy || 'created';
   let orderDirection = args.orderDirection || 'desc';
   if (!['created', 'start', 'end'].includes(orderBy)) orderBy = 'created';

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -221,6 +221,7 @@ input ProposalWhere {
   end_lte: Int
   scores_state: String
   scores_state_in: [String]
+  labels_in: [String]
   state: String
   space_verified: Boolean
   flagged: Boolean


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/254

This PR adds a new `labels_in` filter to proposals where query, to retrieve proposals by labels ID

### Test

```graphql
query { 
  proposals(where: {labels_in: ["764ca440", "ac7c86a4", "84da127c", "7bf634db"]}) {
    id 
  }
}
```