### PR TITLE
fix: Remove proposal check in votes query 

### DIFF
--- a/src/graphql/operations/votes.ts
+++ b/src/graphql/operations/votes.ts
@@ -44,9 +44,8 @@ async function query(parent, args, context?, info?) {
 
   const query = `
     SELECT v.* FROM votes v
-    INNER JOIN proposals p ON v.proposal = p.id
     WHERE 1 = 1 ${queryStr}
-    ORDER BY ${orderBy} ${orderDirection}, v.id ASC LIMIT ?, ?
+    ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?
   `;
   params.push(skip, first);
   try {

--- a/src/graphql/operations/votes.ts
+++ b/src/graphql/operations/votes.ts
@@ -45,7 +45,7 @@ async function query(parent, args, context?, info?) {
   const query = `
     SELECT v.* FROM votes v
     WHERE 1 = 1 ${queryStr}
-    ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?
+    ORDER BY ${orderBy} ${orderDirection}, v.id ASC LIMIT ?, ?
   `;
   params.push(skip, first);
   try {


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot-hub/issues/760

- We don't have votes with `null` proposal
- Removes check for proposal in votes query 


### How to test
- Use this query
```graphql
query ($spaceId: String!, $where: VoteWhere!, $orderDirection: OrderDirection!) {
  votes(where: $where, orderDirection: $orderDirection) {
    created
    voter
  }
  space(id: $spaceId) {
    admins
    members
    moderators
  }
}
```
Variables
```JSON
{
  "spaceId": "arbitrumfoundation.eth",
  "where": {
    "space": "arbitrumfoundation.eth",
    "created_gt": 0
  },
  "orderDirection": "DE"
}
```
- It should be super slow before fix and relatively fast after fix