### PR TITLE
fix: use `AND` operator when searching for multiple labels

### DIFF
--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -73,7 +73,7 @@ export default async function (parent, args) {
   }
 
   if (where?.labels_in?.length) {
-    searchSql += ' AND JSON_OVERLAPS(p.labels, ?)';
+    searchSql += ' AND JSON_CONTAINS(p.labels, ?)';
     params.push(JSON.stringify(where.labels_in));
   }
 


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/254

This PR will change how proposal's labels are searched for.

Currently, `labels_in` operates with the `OR` operator, and when searching for `[1, 2]`, will return proposals with either `1` or `2`.

This PR will change the operator to `AND` (to be consistent with all other existing `_in` filters), so that when searching for `[1, 2]`, will return results for proposals that have both `1` and `2`