### PR TITLE
feat: add discussions and discourseCategory fields to Space

### DIFF
--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -400,6 +400,8 @@ type Space {
   github: String
   coingecko: String
   email: String
+  discussions: String
+  discourseCategory: Int
   network: String
   symbol: String
   skin: String


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/workflow/issues/275

### Summary
- add discussions and discourseCategory fields to Space type

### How to test
- Add these fields to your space using
```sql
UPDATE spaces
SET settings = JSON_SET(settings, '$.discussionLink', 'https://discuss.ens.domains/', '$.discourseCategory', 28)
WHERE id = 'thanku.eth';
```
- Run this query to get space
```GraphQL
{
  space(id:"thanku.eth") {
    id
    discussionLink
    discourseCategory
  }
}
```



