### PR TITLE
fix: update all links with new .box domain

### DIFF
--- a/src/eip4824.ts
+++ b/src/eip4824.ts
@@ -4,6 +4,9 @@ import { getSpace } from './helpers/spaces';
 
 const router = express.Router();
 const context = '<http://www.daostar.org/schemas>';
+const network = process.env.NETWORK || 'testnet';
+const domain = `${network === 'testnet' ? 'testnet.' : ''}snapshot.box`;
+const networkPrefix = network === 'testnet' ? 's-tn' : 's';
 
 router.get('/:space', async (req, res) => {
   let space: any = {};
@@ -86,7 +89,7 @@ router.get('/:space/proposals', async (req, res) => {
       body: proposal.body,
       author: proposal.author,
       ipfs: proposal.ipfs,
-      link: `https://snapshot.org/#/${space.id}/proposal/${proposal.id}`,
+      link: `https://${domain}/#/${networkPrefix}:${id}/proposal/${proposal.id}`
     },
     discussionURI: proposal.discussion,
     status:

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -9,6 +9,7 @@ import { spacesMetadata } from '../helpers/spaces';
 import { jsonParse } from '../helpers/utils';
 
 const network = process.env.NETWORK || 'testnet';
+const domain = `${network === 'testnet' ? 'testnet.' : ''}snapshot.box`;
 
 type AddressFormat = 'evmAddress' | 'starknetAddress';
 const DEFAULT_ADDRESS_FORMAT: AddressFormat[] = [
@@ -411,8 +412,8 @@ export function formatProposal(proposal) {
     flagged: proposal.spaceFlagged,
     hibernated: proposal.spaceHibernated
   });
-  const networkStr = network === 'testnet' ? 'testnet.' : '';
-  proposal.link = `https://${networkStr}snapshot.org/#/${proposal.space.id}/proposal/${proposal.id}`;
+  const networkPrefix = network === 'testnet' ? 's-tn' : 's';
+  proposal.link = `https://${domain}/#/${networkPrefix}:${proposal.space.id}/proposal/${proposal.id}`;
   proposal.strategies = proposal.strategies.map(strategy => ({
     ...strategy,
     // By default return proposal network if strategy network is not defined

--- a/src/helpers/rateLimit.ts
+++ b/src/helpers/rateLimit.ts
@@ -42,7 +42,7 @@ export default rateLimit({
     // log.info(`too many requests ${hashedIp(req)}`);
     sendError(
       res,
-      'too many requests, refer to https://docs.snapshot.org/tools/api/api-keys#limits',
+      'too many requests, refer to https://docs.snapshot.box/tools/api/api-keys#limits',
       429
     );
   },


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/320

This PR will updates all public links to the new .box domain

### How to tests

1. Query with `query { proposals { link } }`
2. The link should use the new .box domain, and space should be prefixed with `s:`
3. In your .env, update `NETWORK` to testnet
4. Domain should be `testnet.snapshot.box` and prefix `s-tn:`
