### PR TITLE
fix: wrong counts

### DIFF
--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -263,6 +263,7 @@ async function loadSpacesMetrics() {
     getProposals(),
     getVotes()
   ]);
+  
   const [followerMetrics, proposalMetrics, voteMetrics] = results;
   Object.keys(spacesMetadata).forEach(space => {
     spacesMetadata[space].counts = {


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/workflow/issues/341

### Summary:
Inside `loadSpacesMetrics`, we were using previous counts if metrics doesn't contain certain properties
```ts
spacesMetadata[space].counts = {
    ...spacesMetadata[space].counts,
    ...metrics
};
```  
- If there are no active proposals then `getProposals` return an object without `activeProposals` property
- If there are no active proposals / recent proposals, then `getProposals` returns empty object
- In these cases, it will show previous counts
- This PR fixes that and uses new counts

### How to test:
- Create a proposal that ends in 5 mins
- Try the following query
```graphql
{
  space(id: "thanku.eth") {
    id
    activeProposals
    proposalsCount1d
    proposalsCount7d
    proposalsCount30d
  }
}
```
- `activeProposals` should be `1`
- Once the proposal end `activeProposals` should be `0`