### PR TITLE
fix: resolve graphql-tools version to 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "prettier": "@snapshot-labs/prettier-config",
   "dependencies": {
-    "@graphql-tools/schema": "^10.0.0",
+    "@graphql-tools/schema": "10.0.0",
     "@snapshot-labs/keycard": "^0.5.1",
     "@snapshot-labs/snapshot-metrics": "^1.4.1",
     "@snapshot-labs/snapshot-sentry": "^1.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,7 +816,7 @@
     "@graphql-tools/utils" "^10.0.0"
     tslib "^2.4.0"
 
-"@graphql-tools/schema@^10.0.0":
+"@graphql-tools/schema@10.0.0":
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-10.0.0.tgz#7b5f6b6a59f51c927de8c9069bde4ebbfefc64b3"
   integrity sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==


### PR DESCRIPTION
Related to https://github.com/ardatan/graphql-tools/issues/6776
- Right now all deployments are failing because of error
```bash
23 16:56:50] │ node_modules/@graphql-tools/utils/typings/fakePromise.d.ts(2,37): error TS1139: Type parameter declaration expected.
[2024-12-23 16:56:50] │ node_modules/@graphql-tools/utils/typings/fakePromise.d.ts(2,44): error TS1005: ',' expected.
[2024-12-23 16:56:50] │ node_modules/@graphql-tools/utils/typings/fakePromise.d.ts(2,51): error TS1005: ')' expected.
[2024-12-23 16:56:50] │ node_modules/@graphql-tools/utils/typings/fakePromise.d.ts(2,53): error TS1434: Unexpected keyword or identifier.
[2024-12-23 16:56:50] │ node_modules/@graphql-tools/utils/typings/fakePromise.d.ts(2,54): error TS1128: Declaration or statement expected.
[2024-12-23 16:56:50] │ node_modules/@graphql-tools/utils/typings/fakePromise.d.ts(2,55): error TS1128: Declaration or statement expected.
[2024-12-2
```
- solution suggests to upgrade typescript to latest version but it doesn't work in our case somehow
- also don't think skiplibcheck is good way to go