### PR TITLE
fix: include networks from delegation strategies

### DIFF
--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -91,11 +91,15 @@ function sortSpaces() {
 
 function mapSpaces() {
   Object.entries(spaces).forEach(([id, space]: any) => {
-    const networks = uniq(
-      (space.strategies || [])
-        .map(strategy => strategy?.network || space.network)
-        .concat(space.network)
-    );
+    const networks = uniq([
+      space.network,
+      ...space.strategies.map((strategy: any) => strategy.network),
+      ...space.strategies.flatMap((strategy: any) =>
+        Array.isArray(strategy.params?.strategies)
+          ? strategy.params.strategies.map((param: any) => param.network)
+          : []
+      )
+    ]);
     const strategyNames = uniq(
       (space.strategies || []).map(strategy => strategy.name)
     );
@@ -263,7 +267,7 @@ async function loadSpacesMetrics() {
     getProposals(),
     getVotes()
   ]);
-  
+
   const [followerMetrics, proposalMetrics, voteMetrics] = results;
   Object.keys(spacesMetadata).forEach(space => {
     spacesMetadata[space].counts = {


### PR DESCRIPTION
Issue:
On the v1 interface it says that there are 10 spaces on the Sonic network but on the v2 interface i only see 7 spaces.

The other three spaces

`heyanondao.eth`: enabled "Hide space from homepage" in settings
`beefydao.eth` and `profit.beefy.eth`: These spaces use this network inside delegation strategy, this PR adds these spaces to response

### How to test:
Use following query, it should return 7 spaces before and 9 spaces after fix
```Graphql
{
  ranking(where: {network: "146"}) {
    metrics {
      total
      categories
    }
    items {
      id
      network
      strategies {
        name
        network
        params
      }
    }
  }
}

```
