### PR TITLE
feat: return premium property for networks

### DIFF
--- a/src/graphql/operations/networks.ts
+++ b/src/graphql/operations/networks.ts
@@ -1,6 +1,7 @@
+import db from '../../helpers/mysql';
 import { spaces } from '../../helpers/spaces';
 
-export default function () {
+export default async function () {
   const networks: any = Object.values(spaces).reduce((acc: any, space: any) => {
     const spaceNetworks = [
       space.network,
@@ -22,8 +23,23 @@ export default function () {
     return acc;
   }, {});
 
-  return Object.entries(networks).map(([id, spacesCount]) => ({
-    id,
-    spacesCount
-  }));
+  const results = Object.entries(networks).reduce((acc, [id, spacesCount]) => {
+    acc[id] = {
+      id,
+      spacesCount: spacesCount,
+      premium: false
+    };
+
+    return acc;
+  }, {});
+
+  const premiumNetworks = await db.queryAsync(
+    'SELECT * FROM networks WHERE premium = 1'
+  );
+  premiumNetworks.forEach((network: any) => {
+    results[network.id] ||= { id: network.id, spacesCount: 0 };
+    results[network.id].premium = true;
+  });
+
+  return Object.values(results);
 }

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -83,7 +83,7 @@ type Query {
 
   skins: [Item]
 
-  networks: [Item]
+  networks: [Network]
 
   validations: [Item]
 
@@ -650,4 +650,10 @@ type Leaderboard {
 type Option {
   name: String
   value: String
+}
+
+type Network {
+  id: String!
+  spacesCount: Int
+  premium: Boolean
 }

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -198,3 +198,10 @@ CREATE TABLE options (
   value VARCHAR(100) NOT NULL,
   PRIMARY KEY (name)
 );
+
+CREATE TABLE networks (
+  id VARCHAR(64) NOT NULL,
+  premium SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+  PRIMARY KEY (id),
+  INDEX premium (premium)
+);


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/389
See https://github.com/snapshot-labs/sx-monorepo/pull/1120#discussion_r1930677289

This PR returns the `premium` property for each network.

For this, a new table will be needed to hold network metadata:

```sql
CREATE TABLE networks (
  id VARCHAR(64) NOT NULL,
  premium SMALLINT UNSIGNED NOT NULL DEFAULT '0',
  PRIMARY KEY (id),
  INDEX premium (premium)
);
```

For now, the table will only contain data for premium network (missing network in this table means non-premium network)

See https://github.com/snapshot-labs/workflow/issues/389#issuecomment-2616078329 for the SQL to import data

### Test

Test with this graphql query 

```graphql
query { 
networks { 
id
spacesCount
premium}
}
```

Which should return something like

```json
{
  "data": {
    "networks": [
      {
        "id": "1",
        "spacesCount": 79904,
        "premium": false
      },
      {
        "id": "3",
        "spacesCount": 36,
        "premium": false
      },
...
```

### Note 

Later, we could move more data to this table, like the `spaces_count`, and all the networks in this table, not just the premiun ones