### PR TITLE
feat: add support for skin logo

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -46,7 +46,8 @@ const SKIN_SETTINGS = [
   'heading_color',
   'header_color',
   'primary_color',
-  'theme'
+  'theme',
+  'logo'
 ];
 
 export function checkLimits(args: any = {}, type) {

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -663,6 +663,7 @@ type SkinSettings {
   header_color: String
   primary_color: String
   theme: String
+  logo: String
 }
 
 type Network {

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -204,6 +204,7 @@ CREATE TABLE skins (
   bg_color VARCHAR(6) DEFAULT NULL,
   link_color VARCHAR(6) DEFAULT NULL,
   text_color VARCHAR(6) DEFAULT NULL,
+  content_color VARCHAR(6) DEFAULT NULL,
   border_color VARCHAR(6) DEFAULT NULL,
   heading_color VARCHAR(6) DEFAULT NULL,
   primary_color VARCHAR(6) DEFAULT NULL,

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -209,9 +209,10 @@ CREATE TABLE skins (
   primary_color VARCHAR(6) DEFAULT NULL,
   header_color VARCHAR(6) DEFAULT NULL,
   theme VARCHAR(5) NOT NULL DEFAULT 'light',
+  logo VARCHAR(256) DEFAULT NULL,
   PRIMARY KEY (id)
 );
-  
+
 CREATE TABLE networks (
   id VARCHAR(64) NOT NULL,
   premium SMALLINT UNSIGNED NOT NULL DEFAULT '0',


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/416
See https://github.com/snapshot-labs/snapshot-sequencer/pull/498 for table creation

This PR will return the `logo` property for the space skin