### PR TITLE
fix: reduce popularty of turbo subspaces

### DIFF
--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -30,6 +30,7 @@ type Metadata = {
   flagged: boolean;
   turbo: boolean;
   hibernated: boolean;
+  parent: string;
   popularity: number;
   rank: number | null;
   private: boolean;
@@ -69,7 +70,7 @@ function getPopularity(space: Metadata): number {
 
   if (space.verified) popularity += 1e10;
 
-  if (space.turbo) popularity += 1e10;
+  if (space.turbo && !space.parent) popularity += 1e10;
 
   return popularity;
 }
@@ -112,6 +113,7 @@ function mapSpaces() {
       flagged: space.flagged,
       turbo: space.turbo,
       hibernated: space.hibernated,
+      parent: space.parent,
       popularity: spacesMetadata[id]?.popularity || 0,
       rank: spacesMetadata[id]?.rank || null,
       private: space.private ?? false,


### PR DESCRIPTION
Increases popularity of turbo space when space doesn't have a parent space