### PR TITLE
feat: add disabled prop to strategy

### DIFF
--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -614,6 +614,7 @@ type StrategyItem {
   examples: [Any]
   about: String
   spacesCount: Int
+  disabled: Boolean
 }
 
 type Treasury {

--- a/src/helpers/strategies.ts
+++ b/src/helpers/strategies.ts
@@ -45,6 +45,7 @@ async function loadStrategies() {
       strategy.id = strategy.key;
       strategy.spacesCount = strategy.spacesCount || 0;
       strategy.verifiedSpacesCount = strategy.verifiedSpacesCount || 0;
+      strategy.disabled = strategy.disabled || false;
       return strategy;
     })
     .sort((a, b): any => b.verifiedSpacesCount - a.verifiedSpacesCount);


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/227

Return `disabled` prop from strategy