### PR TITLE
feat: turbo_expiration_timestamp

### DIFF
--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -437,6 +437,7 @@ type Space {
   flagged: Boolean
   hibernated: Boolean
   turbo: Boolean
+  turbo_expiration_timestamp: Int
   rank: Float
   boost: BoostSettings
   created: Int!

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -437,7 +437,7 @@ type Space {
   flagged: Boolean
   hibernated: Boolean
   turbo: Boolean
-  turbo_expiration_timestamp: Int
+  turbo_expiration: Int
   rank: Float
   boost: BoostSettings
   created: Int!

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE spaces (
   flagged INT NOT NULL DEFAULT '0',
   hibernated INT NOT NULL DEFAULT '0',
   turbo INT NOT NULL DEFAULT '0',
-  turbo_expiration INT NOT NULL DEFAULT '0',
+  turbo_expiration BIGINT NOT NULL DEFAULT '0',
   proposal_count INT NOT NULL DEFAULT '0',
   vote_count INT NOT NULL DEFAULT '0',
   follower_count INT NOT NULL DEFAULT '0',

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE spaces (
   flagged INT NOT NULL DEFAULT '0',
   hibernated INT NOT NULL DEFAULT '0',
   turbo INT NOT NULL DEFAULT '0',
-  turbo_expiration_timestamp INT NOT NULL DEFAULT '0',
+  turbo_expiration INT NOT NULL DEFAULT '0',
   proposal_count INT NOT NULL DEFAULT '0',
   vote_count INT NOT NULL DEFAULT '0',
   follower_count INT NOT NULL DEFAULT '0',

--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -7,6 +7,7 @@ CREATE TABLE spaces (
   flagged INT NOT NULL DEFAULT '0',
   hibernated INT NOT NULL DEFAULT '0',
   turbo INT NOT NULL DEFAULT '0',
+  turbo_expiration_timestamp INT NOT NULL DEFAULT '0',
   proposal_count INT NOT NULL DEFAULT '0',
   vote_count INT NOT NULL DEFAULT '0',
   follower_count INT NOT NULL DEFAULT '0',


### PR DESCRIPTION
See: https://github.com/snapshot-labs/workflow/issues/488#issue-2902688159

Changes proposed in this pull request:
- Adds a `turbo_expiration_timestamp` in the schema.sql
- Adds a `turbo_expiration_timestamp` in the schema.gql
