### PR TITLE
fix: proposal quorum should only work with basic voting

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -450,6 +450,10 @@ export function formatProposal(proposal) {
   }));
   proposal.privacy = proposal.privacy || '';
   proposal.quorumType = proposal.quorum_type || 'default';
+  // quorum should only work with basic voting else use default values
+  const isBasicVoting = proposal.type === 'basic';
+  proposal.quorum = isBasicVoting ? proposal.quorum : 0;
+  proposal.quorumType = isBasicVoting ? proposal.quorumType : 'default';
   return proposal;
 }
 


### PR DESCRIPTION
### Summary
- Added logic to ensure quorum only applies to basic voting types
- Defaulted quorum and quorumType for non-basic voting scenarios

Fixes https://github.com/snapshot-labs/workflow/issues/522

### How to test:
- Start the server and use a query like below:
```graphql
{
  proposals(where:{id:"0xd07e5c85dae5f59dc444838cbfba8ecf6bd5cabdc3e3787bfa7559877bfd2b1d"}) {
    id
    quorum
    quorumType
  }
}
```
| Proposal ID                                                                                                        | Proposal Type | Quorum Type     |  With new changes |
|--------------------------------------------------------------------------------------------------------------------|-------------|------------------|--------|
| [0xd07e5c85dae5f59dc444838cbfba8ecf6bd5cabdc3e3787bfa7559877bfd2b1d](https://snapshot.box/#/s:citizenshouse.eth/proposal/0xd07e5c85dae5f59dc444838cbfba8ecf6bd5cabdc3e3787bfa7559877bfd2b1d) | non-basic   | rejection | default and `0` as value |
| [0x446b08599cd0a3956589e82b5eaed8bb8bbfa570671cca436fafb1b316d0d06c](https://snapshot.box/#/s:citizenshouse.eth/proposal/0x446b08599cd0a3956589e82b5eaed8bb8bbfa570671cca436fafb1b316d0d06c) | basic       | default          | default and same value as before |
| [0x1b1938083ec6b3f630b888d6d7d756aff26f0a0a693ed8f97caf835d04dc1018](https://snapshot.box/#/s:usualmoney.eth/proposal/0x1b1938083ec6b3f630b888d6d7d756aff26f0a0a693ed8f97caf835d04dc1018) | basic       | rejection          | reject and same value as before |
| [0x37c755660a0bbb5812a6b1ed2666b06833874b5187ae8d7536119697d043e85f](https://snapshot.box/#/s:dcip.eth/proposal/0x37c755660a0bbb5812a6b1ed2666b06833874b5187ae8d7536119697d043e85f) | non-basic       | default          | default and `0` as value |
