### PR TITLE
fix: allow sorting with `votes` in proposals query

### DIFF
--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -20,7 +20,8 @@ export default async function (parent, args) {
     start: 'number',
     end: 'number',
     type: 'string',
-    scores_state: 'string'
+    scores_state: 'string',
+    votes: 'number'
   };
   const whereQuery = buildWhereQuery(fields, 'p', where);
   let queryStr = whereQuery.query;
@@ -79,7 +80,8 @@ export default async function (parent, args) {
 
   let orderBy = args.orderBy || 'created';
   let orderDirection = args.orderDirection || 'desc';
-  if (!['created', 'start', 'end'].includes(orderBy)) orderBy = 'created';
+  if (!['created', 'start', 'end', 'votes'].includes(orderBy))
+    orderBy = 'created';
   orderBy = `p.${orderBy}`;
   orderDirection = orderDirection.toUpperCase();
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -224,7 +224,12 @@ input ProposalWhere {
   labels_in: [String]
   state: String
   space_verified: Boolean
-  flagged: Boolean
+  flagged: Boolean,
+  votes: Int,
+  votes_gt: Int,
+  votes_gte: Int,
+  votes_lt: Int,
+  votes_lte: Int,
 }
 
 input VoteWhere {


### PR DESCRIPTION
### Summary
- allow sorting with `votes` in proposals query
- Introduced additional vote filters: `votes`, `votes_gt`, `votes_gte`, `votes_lt`, `votes_lte`

### How to test:
Use queries like:
```Graphql
{
  proposals(orderBy: "votes", orderDirection: desc) {
    votes
  }
}
```
```GraphQL
{
  proposals(orderBy: "votes", orderDirection: desc, where:{votes_gt: 100000}) {
    id
    votes
  }
}

```