### PR TITLE
feat: use turbo expiration field to deduce turbo status

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -143,7 +143,8 @@ export function formatSpace({
   space.verified = verified ?? null;
   space.flagged = flagged ?? null;
   space.hibernated = hibernated ?? null;
-  space.turbo = turbo ?? null;
+  space.turbo =
+    new Date((turboExpiration || 0) * 1000) > new Date() ? true : turbo ?? null;
   space.turboExpiration = turboExpiration ?? 0;
   space.rank = spaceMetadata?.rank ?? null;
 


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/420

Use the new `turbo_expiration` field to deduce a space's turbo status.

In case expiration is empty, will fallback to the previous `turbo` field for backward compatibility.

This is a soft migration, once all the existing turbo spaces have a proper expiration date, we will remove the `turbo` field for good