### PR TITLE
fix: remove usage of global `spaces` object

### DIFF
--- a/src/graphql/operations/plugins.ts
+++ b/src/graphql/operations/plugins.ts
@@ -1,14 +1,16 @@
-import { spaces } from '../../helpers/spaces';
+import { spacesMetadata } from '../../helpers/spaces';
 
-export default function () {
-  const plugins = {};
-  Object.values(spaces).forEach((space: any) => {
-    Object.keys(space.plugins || {}).forEach(plugin => {
-      plugins[plugin] = (plugins[plugin] || 0) + 1;
-    });
-  });
-  return Object.entries(plugins).map(plugin => ({
-    id: plugin[0],
-    spacesCount: plugin[1]
+export default function getPluginsUsage() {
+  const pluginUsageCount: Record<string, number> = {};
+
+  for (const { pluginNames } of Object.values(spacesMetadata)) {
+    for (const plugin of pluginNames) {
+      pluginUsageCount[plugin] = (pluginUsageCount[plugin] || 0) + 1;
+    }
+  }
+
+  return Object.entries(pluginUsageCount).map(([id, spacesCount]) => ({
+    id,
+    spacesCount
   }));
 }

--- a/src/graphql/operations/plugins.ts
+++ b/src/graphql/operations/plugins.ts
@@ -1,6 +1,6 @@
 import { spacesMetadata } from '../../helpers/spaces';
 
-export default function getPluginsUsage() {
+export default function getPlugins() {
   const pluginUsageCount: Record<string, number> = {};
 
   for (const { pluginNames } of Object.values(spacesMetadata)) {

--- a/src/graphql/operations/skins.ts
+++ b/src/graphql/operations/skins.ts
@@ -1,13 +1,16 @@
-import { spaces } from '../../helpers/spaces';
+import { spacesMetadata } from '../../helpers/spaces';
 
-export default function () {
-  const skins = {};
-  Object.values(spaces).forEach((space: any) => {
-    if (space.skin)
-      skins[space.skin] = skins[space.skin] ? skins[space.skin] + 1 : 1;
-  });
-  return Object.entries(skins).map(skin => ({
-    id: skin[0],
-    spacesCount: skin[1]
+export default function getSkins() {
+  const skins: Record<string, number> = {};
+
+  for (const { skin } of Object.values(spacesMetadata)) {
+    if (skin) {
+      skins[skin] = (skins[skin] || 0) + 1;
+    }
+  }
+
+  return Object.entries(skins).map(([id, spacesCount]) => ({
+    id,
+    spacesCount
   }));
 }

--- a/src/graphql/operations/validations.ts
+++ b/src/graphql/operations/validations.ts
@@ -1,14 +1,16 @@
-import { spaces } from '../../helpers/spaces';
+import { spacesMetadata } from '../../helpers/spaces';
 
-export default function () {
-  const validations = {};
-  Object.values(spaces).forEach((space: any) => {
-    if (space.validation)
-      validations[space.validation.name] =
-        (validations[space.validation.name] || 0) + 1;
-  });
-  return Object.entries(validations).map(validation => ({
-    id: validation[0],
-    spacesCount: validation[1]
+export default function getValidations() {
+  const validations: Record<string, number> = {};
+
+  for (const { validationName } of Object.values(spacesMetadata)) {
+    if (validationName) {
+      validations[validationName] = (validations[validationName] || 0) + 1;
+    }
+  }
+
+  return Object.entries(validations).map(([id, spacesCount]) => ({
+    id,
+    spacesCount
   }));
 }

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -19,8 +19,6 @@ const TESTNET_NETWORKS = (
   .filter(network => network.testnet)
   .map(network => network.key);
 
-export let spaces = {};
-
 export let rankedSpaces: Metadata[] = [];
 
 export let networkSpaceCounts: Record<string, number> = {};
@@ -39,6 +37,8 @@ type Metadata = {
   popularity: number;
   rank: number | null;
   private: boolean;
+  skin: string | null;
+  validationName: string | null;
   categories: string[];
   networks: string[];
   counts: {
@@ -100,7 +100,7 @@ function sortSpaces() {
     });
 }
 
-function mapSpaces() {
+function mapSpaces(spaces) {
   networkSpaceCounts = {};
 
   Object.entries(spaces).forEach(([id, space]: any) => {
@@ -136,6 +136,8 @@ function mapSpaces() {
       rank: spacesMetadata[id]?.rank || null,
       private: space.private ?? false,
       categories: space.categories ?? [],
+      skin: space.skin || null,
+      validationName: space.validation?.name || null,
       networks,
       counts: {
         activeProposals: spacesMetadata[id]?.counts?.activeProposals || 0,
@@ -165,7 +167,7 @@ async function loadSpaces() {
     `;
   const results = await db.queryAsync(query);
 
-  spaces = Object.fromEntries(
+  const spaces = Object.fromEntries(
     results.map(space => [
       space.id,
       {
@@ -188,7 +190,7 @@ async function loadSpaces() {
       1000
     ).toFixed()}s)`
   );
-  mapSpaces();
+  mapSpaces(spaces);
 }
 
 async function getProposals(): Promise<

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -100,7 +100,7 @@ function sortSpaces() {
     });
 }
 
-function mapSpaces(spaces) {
+function mapSpaces(spaces: Record<string, Space>) {
   networkSpaceCounts = {};
 
   Object.entries(spaces).forEach(([id, space]: any) => {

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -100,7 +100,7 @@ function sortSpaces() {
     });
 }
 
-function mapSpaces(spaces: Record<string, Space>) {
+function mapSpaces(spaces: Record<string, any>) {
   networkSpaceCounts = {};
 
   Object.entries(spaces).forEach(([id, space]: any) => {

--- a/src/helpers/strategies.ts
+++ b/src/helpers/strategies.ts
@@ -26,21 +26,20 @@ async function loadStrategies() {
     return true;
   }
 
-  Object.values(spacesMetadata).forEach(
-    (space: { verified: boolean; strategyNames: string[] }) => {
-      const ids = new Set<string>(space.strategyNames);
-      ids.forEach(id => {
-        if (res[id]) {
-          res[id].spacesCount = (res[id].spacesCount || 0) + 1;
+  Object.values(spacesMetadata).forEach(({ verified, strategyNames }) => {
+    const ids = new Set<string>(strategyNames);
+    ids.forEach(id => {
+      if (!res[id]) {
+        return;
+      }
 
-          if (space.verified) {
-            res[id].verifiedSpacesCount =
-              (res[id].verifiedSpacesCount || 0) + 1;
-          }
-        }
-      });
-    }
-  );
+      res[id].spacesCount = (res[id].spacesCount || 0) + 1;
+
+      if (verified) {
+        res[id].verifiedSpacesCount = (res[id].verifiedSpacesCount || 0) + 1;
+      }
+    });
+  });
 
   strategies = Object.values(res)
     .map((strategy: any) => {

--- a/src/helpers/strategies.ts
+++ b/src/helpers/strategies.ts
@@ -2,7 +2,7 @@ import { URL } from 'url';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import log from './log';
-import { spaces } from './spaces';
+import { spacesMetadata } from './spaces';
 
 export let strategies: any[] = [];
 export let strategiesObj: any = {};
@@ -26,20 +26,21 @@ async function loadStrategies() {
     return true;
   }
 
-  Object.values(spaces).forEach((space: any) => {
-    const ids = new Set<string>(
-      space.strategies.map(strategy => strategy.name)
-    );
-    ids.forEach(id => {
-      if (res[id]) {
-        res[id].spacesCount = (res[id].spacesCount || 0) + 1;
+  Object.values(spacesMetadata).forEach(
+    (space: { verified: boolean; strategyNames: string[] }) => {
+      const ids = new Set<string>(space.strategyNames);
+      ids.forEach(id => {
+        if (res[id]) {
+          res[id].spacesCount = (res[id].spacesCount || 0) + 1;
 
-        if (space.verified) {
-          res[id].verifiedSpacesCount = (res[id].verifiedSpacesCount || 0) + 1;
+          if (space.verified) {
+            res[id].verifiedSpacesCount =
+              (res[id].verifiedSpacesCount || 0) + 1;
+          }
         }
-      }
-    });
-  });
+      });
+    }
+  );
 
   strategies = Object.values(res)
     .map((strategy: any) => {


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/544

Remove usage and delete the global `spaces` object from helpers/spaces.ts

This object is huge, and contains all the spaces settings, and is also 90% redundant with the `spacesMetadata` object.

Run 

```graphql
query { 
strategies {
  id
  spacesCount
}
}
```

It should return the same results as before this PR. Same with `skins`, `plugins` and `validations` entity.

- before PR app memory usage: 265mb
- after PR app memory usage: 128mb
