### PR TITLE
fix: format spaces with turbo expiration

### DIFF
--- a/src/graphql/operations/ranking.ts
+++ b/src/graphql/operations/ranking.ts
@@ -83,7 +83,15 @@ export default async function (_parent, args, context, info) {
       ORDER BY FIELD(s.id, ?) ASC
     `;
     let spaces = await db.queryAsync(query, [filteredSpaces, filteredSpaces]);
-    spaces = spaces.map(space => Object.assign(space, formatSpace(space)));
+    spaces = spaces.map(space =>
+      Object.assign(
+        space,
+        formatSpace({
+          turboExpiration: space.turbo_expiration,
+          ...space
+        })
+      )
+    );
 
     const items = await handleRelatedSpaces(info, spaces);
 

--- a/src/graphql/operations/votes.ts
+++ b/src/graphql/operations/votes.ts
@@ -70,7 +70,13 @@ async function query(parent, args, context?, info?) {
       let spaces = await db.queryAsync(query, [spaceIds]);
 
       spaces = Object.fromEntries(
-        spaces.map(space => [space.id, formatSpace(space)])
+        spaces.map(space => [
+          space.id,
+          formatSpace({
+            turboExpiration: space.turbo_expiration,
+            ...space
+          })
+        ])
       );
       votes = votes.map(vote => {
         if (spaces[vote.space.id])


### PR DESCRIPTION
### How to test:

```GraphQL
{
  ranking(where: {search: "chaingov.eth"}) {
    items {
      id
      turbo
      turboExpiration
    }
  }
  space(id: "chaingov.eth") {
    id
    turbo
    turboExpiration
  }
}
```

Before it should return false for turbo, after it should return true