### PR TITLE
fix: return shibarium spaces when fetching spaces by controller

### DIFF
--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -535,7 +535,7 @@ async function getControllerDomains(address: string): Promise<string[]> {
       body: JSON.stringify({
         method: 'lookup_domains',
         params: address,
-        network: network === 'testnet' ? '11155111' : '1'
+        network: network === 'testnet' ? ['11155111', '157'] : ['1', '109']
       })
     });
     const { result, error } = (await response.json()) as JsonRpcResponse;


### PR DESCRIPTION
When fetching spaces using the `controller` filter, it was previously only returning spaces from the ens.

This PR adds support for also returning spaces from shibarium

### Test

Set network to `testnet` in .env, and connect to the testnet database

```graphql
query Spaces {
  spaces(first: 20, skip: 0, where: {controller: "0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3"}) {
    id
    name
  }
}
```

This should return a mix of .eth and .shib spaces
