### PR TITLE
perf: optimize messages query

### DIFF
--- a/src/graphql/operations/messages.ts
+++ b/src/graphql/operations/messages.ts
@@ -27,8 +27,9 @@ export default async function (parent, args) {
   orderDirection = orderDirection.toUpperCase();
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
 
+  const useSpaceIndex = where.space ? 'USE INDEX (space)' : '';
   const query = `
-    SELECT m.* FROM messages m
+    SELECT m.* FROM messages m ${useSpaceIndex}
     WHERE id IS NOT NULL ${queryStr}
     ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?
   `;


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/workflow/issues/585

The messages fetching query is using the `timestamp` index, instead of the `space` index, which is more appropriate when filtering by spaces.

This PR forces a query with spaces filtering to use the space index.

### Test

The same graphql mentioned in the issue should resolve in less than 5s

### Note

It's not using multiple index in the `USE INDEX()` (even it supported), from my tests, only using 2 index is as slow as before this PR