### PR TITLE
feat: allow starknet addresses in proposals and votes

### DIFF
--- a/src/graphql/operations/proposals.ts
+++ b/src/graphql/operations/proposals.ts
@@ -12,7 +12,7 @@ export default async function (parent, args) {
     id: 'string',
     ipfs: 'string',
     space: 'string',
-    author: 'evmAddress',
+    author: ['evmAddress', 'starknetAddress'],
     network: 'string',
     created: 'number',
     updated: 'number',

--- a/src/graphql/operations/votes.ts
+++ b/src/graphql/operations/votes.ts
@@ -21,7 +21,7 @@ async function query(parent, args, context?, info?) {
     id: 'string',
     ipfs: 'string',
     space: 'string',
-    voter: 'evmAddress',
+    voter: ['evmAddress', 'starknetAddress'],
     proposal: 'string',
     reason: 'string',
     app: 'string',


### PR DESCRIPTION
Allow passing starknet address when searching:

- proposals by author
- votes by voter

### Tests

```graphql
 query r {
    proposals(where: { author: "0x02a0a8f3b6097e7a6bd7649deb30715323072a159c0e6b71b689bd245c146cc0"}
      ) {
     id
    }
}
```