### PR TITLE
fix: remove undefined keys from the global networks count variable

### DIFF
--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -3,7 +3,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import { Express, Request, Response } from 'express';
 import { GraphQLError, parse } from 'graphql';
 import db from './mysql';
-import { spacesMetadata } from './spaces';
+import { networkSpaceCounts, spacesMetadata } from './spaces';
 import { strategies } from './strategies';
 import operations from '../graphql/operations/';
 
@@ -113,16 +113,8 @@ new client.Gauge({
   help: 'Number of spaces per network',
   labelNames: ['network'],
   async collect() {
-    const results = {};
-    Object.values(spacesMetadata).forEach((space: any) => {
-      space.networks.forEach(network => {
-        results[network] ||= 0;
-        results[network]++;
-      });
-    });
-
-    for (const r in results) {
-      this.set({ network: r }, results[r]);
+    for (const network in networkSpaceCounts) {
+      this.set({ network }, networkSpaceCounts[network]);
     }
   }
 });

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -104,15 +104,17 @@ function mapSpaces(spaces: Record<string, any>) {
   networkSpaceCounts = {};
 
   Object.entries(spaces).forEach(([id, space]: any) => {
-    const networks = uniq([
-      space.network,
-      ...space.strategies.map((strategy: any) => strategy.network),
-      ...space.strategies.flatMap((strategy: any) =>
-        Array.isArray(strategy.params?.strategies)
-          ? strategy.params.strategies.map((param: any) => param.network)
-          : []
-      )
-    ]);
+    const networks = uniq(
+      [
+        space.network,
+        ...space.strategies.map((strategy: any) => strategy.network),
+        ...space.strategies.flatMap((strategy: any) =>
+          Array.isArray(strategy.params?.strategies)
+            ? strategy.params.strategies.map((param: any) => param.network)
+            : []
+        )
+      ].filter(Boolean)
+    );
 
     networks.forEach(network => {
       networkSpaceCounts[network] = (networkSpaceCounts[network] || 0) + 1;


### PR DESCRIPTION
This PR fix an issue where the global `networkSpacesCount` variable contains the key `undefined` as network id, and was counting 30k spaces in it.

This PR fix the issue by ignoring those undefined values

Also improves the metrics, by using the correct global variable to retrieve those stats instead 
 looping the spaces object
### Test

- Go to http://localhost:3000/metrics
- For the lines starting by `spaces_per_network_count`, no more `undefined` network