### PR TITLE
fix: add timeout to fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@snapshot-labs/eslint-config": "^0.1.0-beta.18",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.18",
     "@types/jest": "^29.5.3",
-    "@types/node": "^14.0.13",
+    "@types/node": "^22.0.0",
     "copyfiles": "^2.4.1",
     "dotenv-cli": "^7.2.1",
     "eslint": "^8.28.0",

--- a/src/graphql/helpers.ts
+++ b/src/graphql/helpers.ts
@@ -3,10 +3,9 @@ import graphqlFields from 'graphql-fields';
 import castArray from 'lodash/castArray';
 import intersection from 'lodash/intersection';
 import uniq from 'lodash/uniq';
-import fetch from 'node-fetch';
 import db from '../helpers/mysql';
 import { spacesMetadata } from '../helpers/spaces';
-import { jsonParse } from '../helpers/utils';
+import { fetch, jsonParse } from '../helpers/utils';
 
 const network = process.env.NETWORK || 'testnet';
 const domain = `${network === 'testnet' ? 'testnet.' : ''}snapshot.box`;

--- a/src/helpers/strategies.ts
+++ b/src/helpers/strategies.ts
@@ -3,6 +3,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import log from './log';
 import { spacesMetadata } from './spaces';
+import { fetch } from './utils';
 
 export let strategies: any[] = [];
 export let strategiesObj: any = {};
@@ -17,7 +18,8 @@ const uri = scoreApiURL.toString();
 let consecutiveFailsCount = 0;
 
 async function loadStrategies() {
-  const res = await snapshot.utils.getJSON(uri);
+  const response = await fetch(uri);
+  const res = await response.json();
 
   if (res.hasOwnProperty('error')) {
     capture(new Error('Failed to load strategies'), {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1472,10 +1472,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.5.tgz#9dc0a5cb1ccce4f7a731660935ab70b9c00a5d69"
   integrity sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==
 
-"@types/node@^14.0.13":
-  version "14.14.44"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.44.tgz#df7503e6002847b834371c004b372529f3f85215"
-  integrity sha512-+gaugz6Oce6ZInfI/tK4Pq5wIIkJMEJUu92RB3Eu93mtj4wjjjz9EB5mLp5s1pSsLXdC/CPut/xF20ZzAQJbTA==
+"@types/node@^22.0.0":
+  version "22.16.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.16.5.tgz#cc46ac3994cd957000d0c11095a0b1dae2ea2368"
+  integrity sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==
+  dependencies:
+    undici-types "~6.21.0"
 
 "@types/prettier@^2.1.5":
   version "2.7.3"
@@ -5796,6 +5798,11 @@ undefsafe@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Related to https://discord.com/channels/955773041898573854/1397533764648833154

`fetch` request do not have a timeout by default.

This PR will convert all fetch calls to use our internal one implemented with timeout support.

The issue with the strategies loop seems to come from the fetch call, which hanged (since no error are logged after the last log)