### PR TITLE
feat: return and sort leaderboard by vp_value

### DIFF
--- a/src/graphql/operations/leaderboards.ts
+++ b/src/graphql/operations/leaderboards.ts
@@ -9,7 +9,13 @@ export default async function (parent, args) {
 
   checkLimits(args, 'leaderboards');
 
-  const ORDER_FIELDS = ['vote_count', 'proposal_count', 'last_vote', 'user'];
+  const ORDER_FIELDS = [
+    'vote_count',
+    'proposal_count',
+    'last_vote',
+    'user',
+    'vp_value'
+  ];
   const DEFAULT_ORDER_FIELD = 'vote_count';
 
   const fields = {
@@ -37,7 +43,8 @@ export default async function (parent, args) {
     SELECT l.*,
       l.vote_count as votesCount,
       l.proposal_count as proposalsCount,
-      l.last_vote as lastVote
+      l.last_vote as lastVote,
+      l.vp_value as vpValue
     FROM leaderboard l
     WHERE 1=1 ${whereQuery.query}
     ORDER BY ${orderQuery} LIMIT ?, ?

--- a/src/graphql/schema.gql
+++ b/src/graphql/schema.gql
@@ -225,12 +225,12 @@ input ProposalWhere {
   labels_in: [String]
   state: String
   space_verified: Boolean
-  flagged: Boolean,
-  votes: Int,
-  votes_gt: Int,
-  votes_gte: Int,
-  votes_lt: Int,
-  votes_lte: Int,
+  flagged: Boolean
+  votes: Int
+  votes_gt: Int
+  votes_gte: Int
+  votes_lt: Int
+  votes_lte: Int
   scores_total_value: Float
   scores_total_value_in: [Float]
   scores_total_value_gt: Float
@@ -555,6 +555,7 @@ type Vote {
   vp: Float
   vp_by_strategy: [Float]
   vp_state: String
+  vp_value: Float
 }
 
 type Alias {
@@ -667,6 +668,7 @@ type Leaderboard {
   proposalsCount: Int
   votesCount: Int
   lastVote: Int
+  vpValue: Float
 }
 
 type Option {


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/625

This PR will:

- return vp value for votes and leaderboard
- allow sorting the leaderboard by vp value