### PR TITLE
fix: remove unused index hint

### DIFF
--- a/src/graphql/operations/messages.ts
+++ b/src/graphql/operations/messages.ts
@@ -27,9 +27,8 @@ export default async function (parent, args) {
   orderDirection = orderDirection.toUpperCase();
   if (!['ASC', 'DESC'].includes(orderDirection)) orderDirection = 'DESC';
 
-  const useSpaceIndex = where.space ? 'USE INDEX (space)' : '';
   const query = `
-    SELECT m.* FROM messages m ${useSpaceIndex}
+    SELECT m.* FROM messages m
     WHERE id IS NOT NULL ${queryStr}
     ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?
   `;


### PR DESCRIPTION
### Summary
- removed unused space index hint from SQL query
- This is causing slowness to all other queries that have additional filters
- We can add more indexes on DB if needed

### How to Test
- Try queries like http://localhost:3000/graphql?variables=%7B%0A%20%20%22space%22%3A%20%22gitcoindao.eth%22%2C%0A%20%20%22timestamp_lt%22%3A%201754501663%0A%7D&operationName=GetPreviousSettings&query=query%20GetPreviousSettings(%24space%3A%20String!%2C%20%24timestamp_lt%3A%20Int)%20%7B%0A%20%20messages(first%3A%201%2C%20where%3A%20%7Bspace%3A%20%24space%2C%20type%3A%20%22settings%22%2C%20timestamp_lt%3A%20%24timestamp_lt%7D%2C%20orderBy%3A%20%22timestamp%22%2C%20orderDirection%3A%20desc)%20%7B%0A%20%20%20%20id%0A%20%20%20%20mci%0A%20%20%20%20type%0A%20%20%20%20ipfs%0A%20%20%20%20timestamp%0A%20%20%7D%0A%7D%0A
