### PR TITLE
perf: improve metrics query performance

### DIFF
--- a/src/helpers/mysql.ts
+++ b/src/helpers/mysql.ts
@@ -34,7 +34,9 @@ sequencerConfig.connectTimeout = 60e3;
 sequencerConfig.acquireTimeout = 60e3;
 sequencerConfig.timeout = 60e3;
 sequencerConfig.charset = 'utf8mb4';
-sequencerConfig.ssl = { rejectUnauthorized: sequencerConfig.host !== 'localhost' };
+sequencerConfig.ssl = {
+  rejectUnauthorized: sequencerConfig.host !== 'localhost'
+};
 
 const sequencerDB = mysql.createPool(sequencerConfig);
 


### PR DESCRIPTION
The current query is not using any indices due to the CASE statement. Using `UNION`, we're now able to take advantage of tables indices, and have a more faster query

Before:

![Screenshot 2025-08-23 at 00 38 29](https://github.com/user-attachments/assets/eb3711a5-f76d-4cca-8149-4b750e189386)

After:

![Screenshot 2025-08-23 at 00 38 20](https://github.com/user-attachments/assets/17cd4c5c-803e-44c6-8895-b918e4d850bb)

Notice the time improvement on all metrics (beside rows read), as well as index usage