### PR TITLE
fix: clean up deleted spaces from ranking

### DIFF
--- a/src/graphql/operations/ranking.ts
+++ b/src/graphql/operations/ranking.ts
@@ -77,8 +77,7 @@ export default async function (_parent, args, context, info) {
     if (!filteredSpaces.length) return { items: [], metrics };
 
     const query = `
-      SELECT s.* FROM spaces s WHERE s.deleted = 0
-      AND s.id IN (?)
+      SELECT s.* FROM spaces s WHERE s.id IN (?)
       GROUP BY s.id
       ORDER BY FIELD(s.id, ?) ASC
     `;

--- a/src/helpers/spaces.ts
+++ b/src/helpers/spaces.ts
@@ -24,7 +24,7 @@ export let rankedSpaces: Metadata[] = [];
 
 export let networkSpaceCounts: Record<string, number> = {};
 
-export const spacesMetadata: Record<string, Metadata> = {};
+export let spacesMetadata: Record<string, Metadata> = {};
 
 type Metadata = {
   id: string;
@@ -102,6 +102,7 @@ function sortSpaces() {
 }
 
 function mapSpaces(spaces: Record<string, any>) {
+  spacesMetadata = {};
   networkSpaceCounts = {};
 
   Object.entries(spaces).forEach(([id, space]: any) => {


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/workflow/issues/653

Previously deleted spaces were not properly handled in ranking, because rankedSpaces kept those deleted spaces and they were filtered away in SQL query meaning that we would receive less spaces than expected.

To avoid this we now always clean up old spaces so deleted spaces get removed and in ranking we allow deleted spaces to show up, but this will only happen for around 120s after space was deleted and otherwise ranking will be still functional.
